### PR TITLE
Update `requests` in test_requirements.txt

### DIFF
--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,6 +1,6 @@
 mock
 nose
-requests < 2.9
+requests
 coveralls
 paramiko
 openssh_wrapper

--- a/tests/https_tests.py
+++ b/tests/https_tests.py
@@ -7,7 +7,7 @@ from nose.tools import eq_, ok_
 from proxmoxer import ProxmoxAPI
 
 
-@patch('requests.sessions.Session')
+@patch('requests.Session')
 def test_https_connection(req_session):
     response = {'ticket': 'ticket',
                 'CSRFPreventionToken': 'CSRFPreventionToken'}
@@ -20,7 +20,7 @@ def test_https_connection(req_session):
     eq_(call['verify'], False)
 
 
-@patch('requests.sessions.Session')
+@patch('requests.Session')
 def test_https_connection_wth_port_in_host(req_session):
     response = {'ticket': 'ticket',
                 'CSRFPreventionToken': 'CSRFPreventionToken'}
@@ -33,7 +33,7 @@ def test_https_connection_wth_port_in_host(req_session):
     eq_(call['verify'], False)
 
 
-@patch('requests.sessions.Session')
+@patch('requests.Session')
 def test_https_connection_wth_bad_port_in_host(req_session):
     response = {'ticket': 'ticket',
                 'CSRFPreventionToken': 'CSRFPreventionToken'}
@@ -52,7 +52,7 @@ class TestSuite():
     session = None
 
     # noinspection PyMethodOverriding
-    @patch('requests.sessions.Session')
+    @patch('requests.Session')
     def setUp(self, session):
         response = {'ticket': 'ticket',
                     'CSRFPreventionToken': 'CSRFPreventionToken'}


### PR DESCRIPTION
The version of requests used for tests is really old.
There also is a security bug [CVE-2018-18074
](https://github.com/advisories/GHSA-x84v-xcm2-53pg) that has been fixed in the most recent version.