### PR TITLE
Fix get_tokens() error with API tokens

### DIFF
--- a/proxmoxer/backends/https.py
+++ b/proxmoxer/backends/https.py
@@ -42,14 +42,14 @@ class ProxmoxHTTPAuthBase(AuthBase):
         return cookiejar_from_dict({})
 
     def get_tokens(self):
-        return None
+        return None, None
 
 
 class ProxmoxHTTPAuth(ProxmoxHTTPAuthBase):
     # number of seconds between renewing access tokens (must be less than 7200 to function correctly)
     # if calls are made less frequently than 2 hrs, using the API token auth is reccomended
     renew_age = 3600
-    
+
     def __init__(self, base_url, username, password, verify_ssl=False, timeout=5):
         self.base_url = base_url
         self.username = username
@@ -197,5 +197,5 @@ class Backend(object):
         return JsonSerializer()
 
     def get_tokens(self):
-        """Return the in-use auth and csrf tokens."""
-        return self.auth.pve_auth_cookie, self.auth.csrf_prevention_token
+        """Return the in-use auth and csrf tokens if using user/password auth."""
+        return self.auth.get_tokens()

--- a/proxmoxer/core.py
+++ b/proxmoxer/core.py
@@ -136,7 +136,7 @@ class ProxmoxAPI(ProxmoxResourceBase):
     def get_tokens(self):
         """Return the auth and csrf tokens.
 
-        Returns (None, None) if the backend is not https.
+        Returns (None, None) if the backend is not https using user/password.
         """
         if self._backend_name != 'https':
             return None, None

--- a/tests/https_tests.py
+++ b/tests/https_tests.py
@@ -48,7 +48,10 @@ def test_https_connection_wth_bad_port_in_host(req_session):
 
 @patch('requests.sessions.Session')
 def test_https_api_token(req_session):
-    ProxmoxAPI('proxmox', user='root@pam', api_id='test', api_token='ab27beeb-9ac4-4df1-aa19-62639f27031e', verify_ssl=False)
+    p = ProxmoxAPI('proxmox', user='root@pam', api_id='test', api_token='ab27beeb-9ac4-4df1-aa19-62639f27031e', verify_ssl=False)
+    a, b = p.get_tokens()
+    eq_(a, None)
+    eq_(b, None)
 
 class TestSuite():
     proxmox = None

--- a/tests/https_tests.py
+++ b/tests/https_tests.py
@@ -45,15 +45,6 @@ def test_https_connection_wth_bad_port_in_host(req_session):
     eq_(call['method'], 'post')
     eq_(call['verify'], False)
 
-@patch('requests.sessions.Session')
-def test_https_get_tokens(req_session):
-    response = {'ticket': 'ticket',
-                'CSRFPreventionToken': 'CSRFPreventionToken'}
-    req_session.request.return_value = response
-    p = ProxmoxAPI('proxmox', user='root@pam', password='secret', port=123, verify_ssl=False)
-    eq_(p.get_tokens()[0], 'ticket')
-    eq_(p.get_tokens()[1], 'CSRFPreventionToken')
-
 
 @patch('requests.sessions.Session')
 def test_https_api_token(req_session):

--- a/tests/https_tests.py
+++ b/tests/https_tests.py
@@ -45,13 +45,21 @@ def test_https_connection_wth_bad_port_in_host(req_session):
     eq_(call['method'], 'post')
     eq_(call['verify'], False)
 
+@patch('requests.sessions.Session')
+def test_https_get_tokens(req_session):
+    response = {'ticket': 'ticket',
+                'CSRFPreventionToken': 'CSRFPreventionToken'}
+    req_session.request.return_value = response
+    p = ProxmoxAPI('proxmox', user='root@pam', password='secret', port=123, verify_ssl=False)
+    eq_(p.get_tokens()[0], 'ticket')
+    eq_(p.get_tokens()[1], 'CSRFPreventionToken')
+
 
 @patch('requests.sessions.Session')
 def test_https_api_token(req_session):
     p = ProxmoxAPI('proxmox', user='root@pam', api_id='test', api_token='ab27beeb-9ac4-4df1-aa19-62639f27031e', verify_ssl=False)
-    a, b = p.get_tokens()
-    eq_(a, None)
-    eq_(b, None)
+    eq_(p.get_tokens()[0], None)
+    eq_(p.get_tokens()[1], None)
 
 class TestSuite():
     proxmox = None


### PR DESCRIPTION
calling `get_tokens()` on an API Token auth throws an error. This solves the problem by properly passing the get_token call to the auth rather than the backend and correctly sets a default of (None, None) for the returned tokens.