### PR TITLE
Deprecate old token auth

### DIFF
--- a/proxmoxer/backends/https.py
+++ b/proxmoxer/backends/https.py
@@ -92,6 +92,7 @@ class ProxmoxHTTPAuth(ProxmoxHTTPAuthBase):
         return r
 
 
+# DEPRECATED(1.1.0) - either use a password or the API Tokens
 class ProxmoxHTTPTokenAuth(ProxmoxHTTPAuth):
     """Use existing ticket/token to create a session.
 
@@ -102,6 +103,9 @@ class ProxmoxHTTPTokenAuth(ProxmoxHTTPAuth):
         self.pve_auth_cookie = auth_token
         self.csrf_prevention_token = csrf_token
         self.birth_time = time.time()
+
+        # deprecation notice
+        sys.stderr.write("** Existing token auth is Deprecated as of 1.0.5\n** Please use the API Token Auth for long-running programs\n")
 
 
 class ProxmoxHTTPApiTokenAuth(ProxmoxHTTPAuthBase):
@@ -171,6 +175,7 @@ class Backend(object):
         self.base_url = "https://{0}:{1}/api2/{2}".format(host, port, mode)
 
         if auth_token is not None:
+            # DEPRECATED(1.1.0) - either use a password or the API Tokens
             self.auth = ProxmoxHTTPTokenAuth(auth_token, csrf_token)
         elif api_id is not None:
             self.auth = ProxmoxHTTPApiTokenAuth(user, api_id, api_token)

--- a/proxmoxer/backends/https.py
+++ b/proxmoxer/backends/https.py
@@ -175,9 +175,9 @@ class Backend(object):
 
         self.base_url = "https://{0}:{1}/api2/{2}".format(host, port, mode)
 
-        if auth_ticket is not None:
+        if auth_token is not None:
             # DEPRECATED(1.1.0) - either use a password or the API Tokens
-            self.auth = ProxmoxHTTPTicketAuth(auth_ticket, csrf_token)
+            self.auth = ProxmoxHTTPTicketAuth(auth_token, csrf_token)
         elif token_name is not None:
             self.auth = ProxmoxHTTPApiTokenAuth(user, token_name, token_value)
         elif password is not None:

--- a/tests/https_tests.py
+++ b/tests/https_tests.py
@@ -48,7 +48,7 @@ def test_https_connection_wth_bad_port_in_host(req_session):
 
 @patch('requests.sessions.Session')
 def test_https_api_token(req_session):
-    p = ProxmoxAPI('proxmox', user='root@pam', api_id='test', api_token='ab27beeb-9ac4-4df1-aa19-62639f27031e', verify_ssl=False)
+    p = ProxmoxAPI('proxmox', user='root@pam', token_name='test', token_value='ab27beeb-9ac4-4df1-aa19-62639f27031e', verify_ssl=False)
     eq_(p.get_tokens()[0], None)
     eq_(p.get_tokens()[1], None)
 


### PR DESCRIPTION
The `ProxmoxHTTPTokenAuth` auth is redundant. If the user needs a stateless authentication, the API Token auth can now be used; if the user wants to use the user/password auth, the existing ticket can just be passed as the password and a fresh ticket and CSRF token will be generated.

It will also cause unneeded confusion now with the API Token auth which sounds similar but is completely different.