### PR TITLE
Fix String-based path

### DIFF
--- a/proxmoxer/core.py
+++ b/proxmoxer/core.py
@@ -84,7 +84,7 @@ class ProxmoxResource(ProxmoxResourceBase):
         if resource_id is not None:
             kwargs["base_url"] = self.url_join(self._store["base_url"], *resource_id)
 
-        return self.__class__(**kwargs)
+        return ProxmoxResource(**kwargs)
 
     def _request(self, method, data=None, params=None):
         url = self._store["base_url"]
@@ -141,7 +141,7 @@ class ProxmoxResource(ProxmoxResourceBase):
         return self.put(*args, **data)
 
 
-class ProxmoxAPI(ProxmoxResourceBase):
+class ProxmoxAPI(ProxmoxResource):
     def __init__(self, host, backend='https', **kwargs):
 
         #load backend module


### PR DESCRIPTION
Fix proxmox.nodes.get() and proxmox.get("nodes") returning different values by making the ProxmoxAPI class a subclass of the full resource class (`ProxmoxResource`).

Since the `ProxmoxResourceBase` class is only used by `ProxmoxResource`, it could be refactored out and its contents put into `ProxmoxResource`.
@morph027 what do you think about this?

This is *somewhat* a breaking change as anyone who attempted a workaround to the bug may have breakage. However, any usage following the README will now work.

resolves #49 