### PR TITLE
Allow responses which are not JSON to be handled

### DIFF
--- a/proxmoxer/backends/base_ssh.py
+++ b/proxmoxer/backends/base_ssh.py
@@ -81,8 +81,8 @@ class JsonSimpleSerializer(object):
     def loads(self, response):
         try:
             return json.loads(response.content)
-        except ValueError:
-            return response.content
+        except (UnicodeDecodeError, ValueError, json.decoder.JSONDecodeError):
+            return {"errors": response.content}
 
 
 class BaseBackend(object):

--- a/proxmoxer/backends/base_ssh.py
+++ b/proxmoxer/backends/base_ssh.py
@@ -10,12 +10,6 @@ import logging
 import sys
 from proxmoxer.core import SUPPORTED_SERVICES
 
-try:
-    from json.decoder import JSONDecodeError
-except:
-    # old versions of the json package uses ValueError instead of JSONDecodeError
-    import ValueError as JSONDecodeError
-
 logger = logging.getLogger(__name__)
 logger.setLevel(level=logging.WARNING)
 
@@ -87,7 +81,7 @@ class JsonSimpleSerializer(object):
     def loads(self, response):
         try:
             return json.loads(response.content)
-        except (UnicodeDecodeError, ValueError, JSONDecodeError):
+        except (UnicodeDecodeError, ValueError):
             return {"errors": response.content}
 
 

--- a/proxmoxer/backends/base_ssh.py
+++ b/proxmoxer/backends/base_ssh.py
@@ -10,6 +10,12 @@ import logging
 import sys
 from proxmoxer.core import SUPPORTED_SERVICES
 
+try:
+    from json.decoder import JSONDecodeError
+except:
+    # old versions of the json package uses ValueError instead of JSONDecodeError
+    import ValueError as JSONDecodeError
+
 logger = logging.getLogger(__name__)
 logger.setLevel(level=logging.WARNING)
 
@@ -81,7 +87,7 @@ class JsonSimpleSerializer(object):
     def loads(self, response):
         try:
             return json.loads(response.content)
-        except (UnicodeDecodeError, ValueError, json.decoder.JSONDecodeError):
+        except (UnicodeDecodeError, ValueError, JSONDecodeError):
             return {"errors": response.content}
 
 

--- a/proxmoxer/backends/https.py
+++ b/proxmoxer/backends/https.py
@@ -158,8 +158,8 @@ class JsonSerializer(object):
     def loads(self, response):
         try:
             return json.loads(response.content.decode('utf-8'))['data']
-        except (UnicodeDecodeError, ValueError):
-            return response.content
+        except (UnicodeDecodeError, ValueError, json.decoder.JSONDecodeError):
+            return {"errors": response.content}
 
 
 class ProxmoxHttpSession(requests.Session):

--- a/proxmoxer/backends/https.py
+++ b/proxmoxer/backends/https.py
@@ -22,12 +22,6 @@ except ImportError:
     logger.error("Chosen backend requires 'requests' module\n")
     sys.exit(1)
 
-try:
-    from json.decoder import JSONDecodeError
-except:
-    # old versions of the json package uses ValueError instead of JSONDecodeError
-    import ValueError as JSONDecodeError
-
 if sys.version_info[0] >= 3:
     import io
     def is_file(obj): return isinstance(obj, io.IOBase)
@@ -164,7 +158,7 @@ class JsonSerializer(object):
     def loads(self, response):
         try:
             return json.loads(response.content.decode('utf-8'))['data']
-        except (UnicodeDecodeError, ValueError, JSONDecodeError):
+        except (UnicodeDecodeError, ValueError):
             return {"errors": response.content}
 
 

--- a/proxmoxer/backends/https.py
+++ b/proxmoxer/backends/https.py
@@ -22,6 +22,12 @@ except ImportError:
     logger.error("Chosen backend requires 'requests' module\n")
     sys.exit(1)
 
+try:
+    from json.decoder import JSONDecodeError
+except:
+    # old versions of the json package uses ValueError instead of JSONDecodeError
+    import ValueError as JSONDecodeError
+
 if sys.version_info[0] >= 3:
     import io
     def is_file(obj): return isinstance(obj, io.IOBase)
@@ -158,7 +164,7 @@ class JsonSerializer(object):
     def loads(self, response):
         try:
             return json.loads(response.content.decode('utf-8'))['data']
-        except (UnicodeDecodeError, ValueError, json.decoder.JSONDecodeError):
+        except (UnicodeDecodeError, ValueError, JSONDecodeError):
             return {"errors": response.content}
 
 

--- a/proxmoxer/core.py
+++ b/proxmoxer/core.py
@@ -97,21 +97,13 @@ class ProxmoxResource(ProxmoxResourceBase):
 
         if resp.status_code >= 400:
             if hasattr(resp, 'reason'):
-                if resp.json().get('errors') != None:
-                    raise ResourceException(
-                        resp.status_code,
-                        httplib.responses.get(resp.status_code,
-                                            ANYEVENT_HTTP_STATUS_CODES.get(resp.status_code)),
-                        resp.reason,
-                        resp.json()["errors"]
-                    )
-                else:
-                    raise ResourceException(
-                        resp.status_code,
-                        httplib.responses.get(resp.status_code,
-                                            ANYEVENT_HTTP_STATUS_CODES.get(resp.status_code)),
-                        resp.reason
-                    )
+                raise ResourceException(
+                    resp.status_code,
+                    httplib.responses.get(resp.status_code,
+                                        ANYEVENT_HTTP_STATUS_CODES.get(resp.status_code)),
+                    resp.reason,
+                    self._store["serializer"].loads(resp).get('errors')
+                )
             else:
                 raise ResourceException(
                     resp.status_code,


### PR DESCRIPTION
Rather than raising a JSONDecodeError, a ResourceException will be raised with the raw response text as the error.

If the return code is a 2xx code, it will return a dictionary with the text under the key "errors" (e.g. `{"errors": "this was a non-JSON response"}`). While this key name does not exactly describe the contents, it makes the raising of the ResourceException possible and a "successful" API call that does not actually return JSON is (in my opinion) an error.