### PR TITLE
Add devcontainer support for easier development

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -5,8 +5,8 @@ ARG VARIANT="3"
 FROM mcr.microsoft.com/vscode/devcontainers/python:0-${VARIANT}
 
 # [Optional] If your pip requirements rarely change, uncomment this section to add them to the image.
-COPY test_requirements.txt /tmp/pip-tmp/
-RUN pip3 --disable-pip-version-check --no-cache-dir install -r /tmp/pip-tmp/test_requirements.txt \
+COPY test_requirements.txt dev_requirements.txt /tmp/pip-tmp/
+RUN pip3 --disable-pip-version-check --no-cache-dir install -r /tmp/pip-tmp/test_requirements.txt -r /tmp/pip-tmp/dev_requirements.txt \
    && rm -rf /tmp/pip-tmp
 
 # [Optional] Uncomment this section to install additional OS packages.

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,14 @@
+# See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.166.1/containers/python-3/.devcontainer/base.Dockerfile
+
+# [Choice] Python version: 3, 3.9, 3.8, 3.7, 3.6
+ARG VARIANT="3"
+FROM mcr.microsoft.com/vscode/devcontainers/python:0-${VARIANT}
+
+# [Optional] If your pip requirements rarely change, uncomment this section to add them to the image.
+COPY test_requirements.txt /tmp/pip-tmp/
+RUN pip3 --disable-pip-version-check --no-cache-dir install -r /tmp/pip-tmp/test_requirements.txt \
+   && rm -rf /tmp/pip-tmp
+
+# [Optional] Uncomment this section to install additional OS packages.
+# RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+#     && apt-get -y install --no-install-recommends <your-package-list-here>

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,41 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
+// https://github.com/microsoft/vscode-dev-containers/tree/v0.166.1/containers/python-3
+{
+  "name": "Proxmoxer Development",
+  "build": {
+    "dockerfile": "Dockerfile",
+    "context": "..",
+    "args": {
+      // Update 'VARIANT' to pick a Python version: 3, 3.6, 3.7, 3.8, 3.9
+      "VARIANT": "3",
+    }
+  },
+  // Set *default* container specific settings.json values on container create.
+  "settings": {
+    "terminal.integrated.shell.linux": "/bin/bash",
+    "python.pythonPath": "/usr/local/bin/python",
+    "python.linting.enabled": true,
+    "python.linting.pylintEnabled": true,
+    "python.formatting.autopep8Path": "/usr/local/py-utils/bin/autopep8",
+    "python.formatting.blackPath": "/usr/local/py-utils/bin/black",
+    "python.formatting.yapfPath": "/usr/local/py-utils/bin/yapf",
+    "python.linting.banditPath": "/usr/local/py-utils/bin/bandit",
+    "python.linting.flake8Path": "/usr/local/py-utils/bin/flake8",
+    "python.linting.mypyPath": "/usr/local/py-utils/bin/mypy",
+    "python.linting.pycodestylePath": "/usr/local/py-utils/bin/pycodestyle",
+    "python.linting.pydocstylePath": "/usr/local/py-utils/bin/pydocstyle",
+    "python.linting.pylintPath": "/usr/local/py-utils/bin/pylint"
+  },
+  // Add the IDs of extensions you want installed when the container is created.
+  "extensions": [
+	"ms-python.python",
+	"streetsidesoftware.code-spell-checker",
+	"mhutchie.git-graph"
+],
+  // Use 'forwardPorts' to make a list of ports inside the container available locally.
+  // "forwardPorts": [],
+  // Use 'postCreateCommand' to run commands after the container is created.
+  // "postCreateCommand": "pip3 install --user -r requirements.txt",
+  // Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
+  "remoteUser": "vscode"
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -28,10 +28,10 @@
   },
   // Add the IDs of extensions you want installed when the container is created.
   "extensions": [
-	"ms-python.python",
-	"streetsidesoftware.code-spell-checker",
-	"mhutchie.git-graph"
-],
+    "ms-python.python",
+    "streetsidesoftware.code-spell-checker",
+    "mhutchie.git-graph"
+  ],
   // Use 'forwardPorts' to make a list of ports inside the container available locally.
   // "forwardPorts": [],
   // Use 'postCreateCommand' to run commands after the container is created.

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,11 @@
+{
+  "cSpell.words": [
+    "Butovich",
+    "cpus",
+    "Oleg",
+    "onboot",
+    "Paramiko",
+    "proxmoxer",
+    "vmid"
+  ],
+}

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,0 +1,2 @@
+twine
+setuptools

--- a/proxmoxer/backends/https.py
+++ b/proxmoxer/backends/https.py
@@ -25,7 +25,7 @@ except ImportError:
 if sys.version_info[0] >= 3:
     import io
     def is_file(obj): return isinstance(obj, io.IOBase)
-    # prefer using monotomic time if available
+    # prefer using monoatomic time if available
     def get_time(): return time.monotonic()
 else:
     def is_file(obj): return isinstance(obj, file)
@@ -107,7 +107,7 @@ class ProxmoxHTTPAuth(ProxmoxHTTPAuthBase):
             logger.debug("refreshing ticket (age {0})".format(get_time() - self.birth_time))
             self._getNewTokens()
 
-        # only attach CRSF token if needed (reduce interception risk)
+        # only attach CSRF token if needed (reduce interception risk)
         if r.method != 'GET':
             r.headers["CSRFPreventionToken"] = self.csrf_prevention_token
         return r


### PR DESCRIPTION
Add a (mostly default) devcontainer definition to allow easy development in a repeatable and disposable environment.

To use a devcontainer:
1. Install Docker ([Instructions](https://www.docker.com/get-started))
2. Install Visual Studio Code ([Instructions](https://code.visualstudio.com/download))
3. Install the ["Remote - Containers" extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers)
4. Clone this repository into a container ([Instructions](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers))

I'll be creating a PR soon that adds a CONTRIBUTING file with setup instructions with and without the devcontainer.