### PR TITLE
Move CI to GitHub Actions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -44,15 +44,14 @@ jobs:
         run: pip3 install .
 
       - name: Run Tests
-        run: nosetests --with-coverage --cover-xml --cover-erase --cover-branches --cover-package=proxmoxer tests/
+        run: nosetests --with-coverage --cover-erase --cover-branches --cover-package=proxmoxer tests/
 
-      - name: Send Coverage
-        uses: coverallsapp/github-action@1.1.3
-        with:
-          parallel: true
-          flag-name: Unit Test (${{ matrix.python-version }})
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          path-to-lcov: coverage.xml
+      - name: Upload coverage data to coveralls.io
+        run: coveralls --service=github
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COVERALLS_FLAG_NAME: Unit Test (${{ matrix.python-version }})
+          COVERALLS_PARALLEL: true
 
 
   complete:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -52,7 +52,7 @@ jobs:
 
       - name: Setup for Python 2
         if: ${{ matrix.python-version == '2.7' }}
-        run: export COVERALLS_REPO_TOKEN="${GITHUB_TOKEN}"
+        run: echo COVERALLS_REPO_TOKEN="${GITHUB_TOKEN}"
       - name: Upload coverage data to coveralls.io
         run: coveralls --service=github
         env:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -47,7 +47,7 @@ jobs:
         run: nosetests --with-coverage --cover-erase --cover-branches --cover-package=proxmoxer tests/
 
       - name: Upload coverage data to coveralls.io
-        run: coveralls --service=github
+        run: coveralls --service=github-actions
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           COVERALLS_FLAG_NAME: Unit Test (${{ matrix.python-version }})

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -44,7 +44,7 @@ jobs:
         run: pip3 install .
 
       - name: Run Tests
-        run: nosetests --with-coverage --cover-erase --cover-branches --cover-package=proxmoxer -w tests
+        run: nosetests --with-coverage --cover-xml --cover-erase --cover-branches --cover-package=proxmoxer tests/
 
       - name: Send Coverage
         uses: coverallsapp/github-action@1.1.3
@@ -52,7 +52,7 @@ jobs:
           parallel: true
           flag-name: Unit Test (${{ matrix.python-version }})
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          path-to-lcov: .coverage
+          path-to-lcov: coverage.xml
 
 
   complete:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,63 @@
+name: CI
+
+on:
+  pull-request:
+
+   # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  unit-test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version:
+          - 2.7
+          - 3.4
+          - 3.8
+          - 3.9
+          - 3.10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Cache PIP packages
+        uses: actions/cache@v2
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-python${{ matrix.python-version }}-${{ hashFiles('*requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-python${{ matrix.python-version }}-
+            ${{ runner.os }}-pip-
+
+      - name: Install pip Packages
+        run: pip3 install -r test_requirements.txt
+
+      - name: Install Self as Package
+        run: pip3 install .
+
+      - name: Run Tests
+        run: nosetests --with-coverage --cover-erase --cover-branches --cover-package=proxmoxer -w tests
+
+      - name: Send Coverage
+        uses: coverallsapp/github-action@1.1.3
+        with:
+          parallel: true
+          flag-name: Unit Test (${{ matrix.python-version }})
+
+
+  complete:
+    needs: unit-test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Coveralls Finished
+        uses: coverallsapp/github-action@1.1.3
+        with:
+          parallel-finished: true

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,10 +14,11 @@ jobs:
       matrix:
         python-version:
           - "2.7"
-          - "3.4"
+          - "3.5"
+          - "3.7"
           - "3.8"
           - "3.9"
-          - "3.10"
+          # - "3.10"
 
     steps:
       - name: Checkout
@@ -47,7 +48,7 @@ jobs:
         run: nosetests --with-coverage --cover-erase --cover-branches --cover-package=proxmoxer tests/
 
       - name: Upload coverage data to coveralls.io
-        run: coveralls debug --service=github
+        run: coveralls --service=github
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           COVERALLS_FLAG_NAME: Unit Test (${{ matrix.python-version }})

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,11 +13,11 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-          - 2.7
-          - 3.4
-          - 3.8
-          - 3.9
-          - 3.10
+          - "2.7"
+          - "3.4"
+          - "3.8"
+          - "3.9"
+          - "3.10"
 
     steps:
       - name: Checkout

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,7 +1,7 @@
 name: CI
 
 on:
-  pull-request:
+  pull_request:
 
    # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -47,7 +47,7 @@ jobs:
         run: nosetests --with-coverage --cover-erase --cover-branches --cover-package=proxmoxer tests/
 
       - name: Upload coverage data to coveralls.io
-        run: coveralls --service=github-actions
+        run: coveralls debug --service=github
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           COVERALLS_FLAG_NAME: Unit Test (${{ matrix.python-version }})

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,6 +3,8 @@ name: CI
 on:
   pull_request:
 
+  push:
+
    # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,8 +3,6 @@ name: CI
 on:
   pull_request:
 
-  push:
-
    # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
@@ -50,15 +48,13 @@ jobs:
       - name: Run Tests
         run: nosetests --with-coverage --cover-erase --cover-branches --cover-package=proxmoxer tests/
 
-      - name: Setup for Python 2
-        if: ${{ matrix.python-version == '2.7' }}
-        run: echo COVERALLS_REPO_TOKEN="${GITHUB_TOKEN}"
       - name: Upload coverage data to coveralls.io
         run: coveralls --service=github
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           COVERALLS_FLAG_NAME: Unit Test (${{ matrix.python-version }})
           COVERALLS_PARALLEL: true
+          COVERALLS_REPO_TOKEN: ${{ matrix.python-version == '2.7' && secrets.GITHUB_TOKEN || ''}}
 
 
   complete:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -51,7 +51,7 @@ jobs:
         run: nosetests --with-coverage --cover-erase --cover-branches --cover-package=proxmoxer tests/
 
       - name: Setup for Python 2
-        if: ${{ matrix.python-version == "2.7" }}
+        if: ${{ matrix.python-version == '2.7' }}
         run: export COVERALLS_REPO_TOKEN="${GITHUB_TOKEN}"
       - name: Upload coverage data to coveralls.io
         run: coveralls --service=github

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -50,15 +50,19 @@ jobs:
       - name: Run Tests
         run: nosetests --with-coverage --cover-erase --cover-branches --cover-package=proxmoxer tests/
 
+      - name: Setup for Python 2
+        if: ${{ matrix.python-version == "2.7" }}
+        run: export COVERALLS_REPO_TOKEN="${GITHUB_TOKEN}"
       - name: Upload coverage data to coveralls.io
         run: coveralls --service=github
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # COVERALLS_FLAG_NAME: Unit Test (${{ matrix.python-version }})
+          COVERALLS_FLAG_NAME: Unit Test (${{ matrix.python-version }})
           COVERALLS_PARALLEL: true
 
 
   complete:
+    name: Finalize Coveralls Report
     needs: unit-test
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,6 +10,7 @@ on:
 
 jobs:
   unit-test:
+    continue-on-error: true
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -51,6 +51,7 @@ jobs:
         with:
           parallel: true
           flag-name: Unit Test (${{ matrix.python-version }})
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
 
   complete:
@@ -61,3 +62,4 @@ jobs:
         uses: coverallsapp/github-action@1.1.3
         with:
           parallel-finished: true
+          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -52,6 +52,7 @@ jobs:
           parallel: true
           flag-name: Unit Test (${{ matrix.python-version }})
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          path-to-lcov: .coverage
 
 
   complete:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,10 +39,10 @@ jobs:
             ${{ runner.os }}-pip-
 
       - name: Install pip Packages
-        run: pip3 install -r test_requirements.txt
+        run: pip install -r test_requirements.txt
 
       - name: Install Self as Package
-        run: pip3 install .
+        run: pip install .
 
       - name: Run Tests
         run: nosetests --with-coverage --cover-erase --cover-branches --cover-package=proxmoxer tests/
@@ -51,7 +51,7 @@ jobs:
         run: coveralls --service=github
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          COVERALLS_FLAG_NAME: Unit Test (${{ matrix.python-version }})
+          # COVERALLS_FLAG_NAME: Unit Test (${{ matrix.python-version }})
           COVERALLS_PARALLEL: true
 
 


### PR DESCRIPTION
Travis CI has been very unreliable recently. I did all the work of requesting Open Source build credits and then they just disappeared.

This PR moves to using GitHub Actions for CI needs.