### PR TITLE
Fix display of API errors in ProxmoxResource._request

### DIFF
--- a/proxmoxer/backends/https.py
+++ b/proxmoxer/backends/https.py
@@ -156,6 +156,12 @@ class JsonSerializer(object):
         except (UnicodeDecodeError, ValueError):
             return {"errors": response.content}
 
+    def loads_errors(self, response):
+        try:
+            return json.loads(response.text)['errors']
+        except (UnicodeDecodeError, ValueError):
+            return {"errors": response.content}
+
 
 class ProxmoxHttpSession(requests.Session):
 

--- a/proxmoxer/core.py
+++ b/proxmoxer/core.py
@@ -107,7 +107,7 @@ class ProxmoxResource(ProxmoxResourceBase):
                     httplib.responses.get(resp.status_code,
                                         ANYEVENT_HTTP_STATUS_CODES.get(resp.status_code)),
                     resp.reason,
-                    (self._store["serializer"].loads(resp) or {}).get('errors')
+                    errors=(self._store["serializer"].loads_errors(resp) or {})
                 )
             else:
                 raise ResourceException(


### PR DESCRIPTION
While I was working on the Ansible proxmox module, which uses this API wrapper, I found that when you get a `400 Bad Request: Parameter verification failed` error, the Proxmox API actually sends what is wrong with the parameters you send. However, proxmoxer does not add this information in the `ResourceException`. Here is an example of the JSON with an error that is sent back by the Proxmox API (PVE v7.1-8):
```json
{
  "data": null
  "errors": {
    "password": "value must be at least 5 characters long"
  }
}
```

I found that this was because of the way `JsonSerializer.loads` works. It always only sends the `data` part of the JSON back, which does not include the errors. Because I didn't want to affect other behaviour, I created a new method for sending the errors back. Obviously it is also possible to just change the way `JsonSerializer.loads` works, but that will probably require changes elsewhere.