### PR TITLE
Enable proper handling of QEMU exec commands

### DIFF
--- a/proxmoxer/backends/command_base.py
+++ b/proxmoxer/backends/command_base.py
@@ -7,6 +7,7 @@ import json
 import logging
 import re
 from itertools import chain
+from shlex import split as shell_split
 
 from proxmoxer.core import SERVICES
 
@@ -61,9 +62,21 @@ class CommandBaseSession(object):
 
         cmd = {"post": "create", "put": "set"}.get(method, method)
 
+        # separate out qemu exec commands to split into multiple argument pairs (issue#89)
+        data_command = data.get("command")
+        if data_command is not None:
+            del data["command"]
+
         command = ["{0}sh".format(self.service), cmd, url]
         # convert the options dict into a 2-tuple with the key formatted as a flag
         option_pairs = [("-{0}".format(k), str(v)) for k, v in chain(data.items(), params.items())]
+        # add back in all the command arguments as their own pairs
+        if data_command is not None:
+            command_arr = (
+                data_command if isinstance(data_command, list) else shell_split(data_command)
+            )
+            for arg in command_arr:
+                option_pairs.append(("-command", arg))
         # expand the list of 2-tuples into a flat list
         options = [val for pair in option_pairs for val in pair]
         additional_options = SERVICES[self.service.upper()].get("ssh_additional_options", [])

--- a/proxmoxer/backends/command_base.py
+++ b/proxmoxer/backends/command_base.py
@@ -90,7 +90,7 @@ class CommandBaseSession(object):
         stdout, stderr = self._exec(full_cmd)
 
         def is_http_status_string(s):
-            return re.match(r"\d\d\d [a-zA-Z]", s)
+            return re.match(r"\d\d\d [a-zA-Z]", str(s))
 
         if stderr:
             # sometimes contains extra text like 'trying to acquire lock...OK'

--- a/proxmoxer/backends/command_base.py
+++ b/proxmoxer/backends/command_base.py
@@ -63,9 +63,11 @@ class CommandBaseSession(object):
         cmd = {"post": "create", "put": "set"}.get(method, method)
 
         # separate out qemu exec commands to split into multiple argument pairs (issue#89)
-        data_command = data.get("command")
-        if data_command is not None:
-            del data["command"]
+        data_command = None
+        if "/agent/exec" in url:
+            data_command = data.get("command")
+            if data_command is not None:
+                del data["command"]
 
         command = ["{0}sh".format(self.service), cmd, url]
         # convert the options dict into a 2-tuple with the key formatted as a flag

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -5,3 +5,4 @@ coveralls
 paramiko
 openssh_wrapper
 testfixtures
+shellescape

--- a/tests/base/base_suite.py
+++ b/tests/base/base_suite.py
@@ -192,21 +192,25 @@ class CommandBaseSuite(object):
         self.proxmox.nodes("proxmox").get()
 
     def test_qemu_command_string(self):
-        self.proxmox.nodes("proxmox").qemu(100).agent.exec.post(
+        # "TMP" added to path to resolve Python 2.7 SyntaxError with "exec" here
+        self.proxmox.nodes("proxmox").qemu(100).agent.execTMP.post(
             command='bash -c "sleep 5 && echo \'hello \\"world\\"\'"'
         )
         eq_(
             self._get_called_cmd(),
             self._called_cmd(
-                'pvesh create /nodes/proxmox/qemu/100/agent/exec -command bash -command -c -command "sleep 5 && echo \'hello \\"world\\"\'" --output-format json'
+                'pvesh create /nodes/proxmox/qemu/100/agent/execTMP -command bash -command -c -command "sleep 5 && echo \'hello \\"world\\"\'" --output-format json'
             ),
         )
 
     def test_qemu_command_array(self):
-        self.proxmox.nodes("proxmox").qemu(100).agent.exec.post(command=["echo", 'hello "world"'])
+        # "TMP" added to path to resolve Python 2.7 SyntaxError with "exec" here
+        self.proxmox.nodes("proxmox").qemu(100).agent.execTMP.post(
+            command=["echo", 'hello "world"']
+        )
         eq_(
             self._get_called_cmd(),
             self._called_cmd(
-                "pvesh create /nodes/proxmox/qemu/100/agent/exec -command echo -command 'hello \"world\"' --output-format json"
+                "pvesh create /nodes/proxmox/qemu/100/agent/execTMP -command echo -command 'hello \"world\"' --output-format json"
             ),
         )

--- a/tests/base/base_suite.py
+++ b/tests/base/base_suite.py
@@ -77,28 +77,28 @@ class CommandBaseSuite(object):
         eq_(result[4]["subdir"], "rrddata")
 
     def test_delete(self):
-        self.proxmox.nodes("proxmox").openvz(100).delete()
+        self.proxmox.nodes("proxmox").qemu(100).delete()
         eq_(
             self._get_called_cmd(),
-            self._called_cmd("pvesh delete /nodes/proxmox/openvz/100 --output-format json"),
+            self._called_cmd("pvesh delete /nodes/proxmox/qemu/100 --output-format json"),
         )
         self._set_output(stderr="200 OK")
-        self.proxmox.nodes("proxmox").openvz("101").delete()
+        self.proxmox.nodes("proxmox").qemu("101").delete()
         eq_(
             self._get_called_cmd(),
-            self._called_cmd("pvesh delete /nodes/proxmox/openvz/101 --output-format json"),
+            self._called_cmd("pvesh delete /nodes/proxmox/qemu/101 --output-format json"),
         )
         self._set_output(stderr="200 OK")
-        self.proxmox.nodes("proxmox").openvz.delete("102")
+        self.proxmox.nodes("proxmox").qemu.delete("102")
         eq_(
             self._get_called_cmd(),
-            self._called_cmd("pvesh delete /nodes/proxmox/openvz/102 --output-format json"),
+            self._called_cmd("pvesh delete /nodes/proxmox/qemu/102 --output-format json"),
         )
 
     def test_post(self):
         self._set_output(stderr="200 OK")
         node = self.proxmox.nodes("proxmox")
-        node.openvz.create(
+        node.qemu.create(
             vmid=800,
             ostemplate="local:vztmpl/debian-6-turnkey-core_12.0-1_i386.tar.gz",
             hostname="test",
@@ -111,7 +111,7 @@ class CommandBaseSuite(object):
             ip_address="10.0.100.222",
         )
         cmd, options = self._split_cmd(self._get_called_cmd())
-        eq_(cmd, "create /nodes/proxmox/openvz")
+        eq_(cmd, "create /nodes/proxmox/qemu")
         ok_("-cpus 1" in options)
         ok_("-disk 4" in options)
         ok_("-hostname test" in options)
@@ -125,7 +125,7 @@ class CommandBaseSuite(object):
 
         self._set_output(stderr="200 OK")
         node = self.proxmox.nodes("proxmox1")
-        node.openvz.post(
+        node.qemu.post(
             vmid=900,
             ostemplate="local:vztmpl/debian-7-turnkey-core_12.0-1_i386.tar.gz",
             hostname="test1",
@@ -138,7 +138,7 @@ class CommandBaseSuite(object):
             ip_address="10.0.100.111",
         )
         cmd, options = self._split_cmd(self._get_called_cmd())
-        eq_(cmd, "create /nodes/proxmox1/openvz")
+        eq_(cmd, "create /nodes/proxmox1/qemu")
         ok_("-cpus 2" in options)
         ok_("-disk 8" in options)
         ok_("-hostname test1" in options)
@@ -153,9 +153,9 @@ class CommandBaseSuite(object):
     def test_put(self):
         self._set_output(stderr="200 OK")
         node = self.proxmox.nodes("proxmox")
-        node.openvz(101).config.set(cpus=4, memory=1024, ip_address="10.0.100.100", onboot=True)
+        node.qemu(101).config.set(cpus=4, memory=1024, ip_address="10.0.100.100", onboot=True)
         cmd, options = self._split_cmd(self._get_called_cmd())
-        eq_(cmd, "set /nodes/proxmox/openvz/101/config")
+        eq_(cmd, "set /nodes/proxmox/qemu/101/config")
         ok_("-memory 1024" in options)
         ok_("-ip_address 10.0.100.100" in options)
         ok_("-onboot True" in options)
@@ -163,9 +163,9 @@ class CommandBaseSuite(object):
 
         self._set_output(stderr="200 OK")
         node = self.proxmox.nodes("proxmox1")
-        node.openvz("102").config.put(cpus=2, memory=512, ip_address="10.0.100.200", onboot=False)
+        node.qemu("102").config.put(cpus=2, memory=512, ip_address="10.0.100.200", onboot=False)
         cmd, options = self._split_cmd(self._get_called_cmd())
-        eq_(cmd, "set /nodes/proxmox1/openvz/102/config")
+        eq_(cmd, "set /nodes/proxmox1/qemu/102/config")
         ok_("-memory 512" in options)
         ok_("-ip_address 10.0.100.200" in options)
         ok_("-onboot False" in options)

--- a/tests/https_tests.py
+++ b/tests/https_tests.py
@@ -145,20 +145,20 @@ class TestSuite:
         )
 
     def test_delete(self):
-        self.proxmox.nodes("proxmox").openvz(100).delete()
+        self.proxmox.nodes("proxmox").qemu(100).delete()
         eq_(
             self.session.request.call_args[0],
-            ("DELETE", "https://proxmox:123/api2/json/nodes/proxmox/openvz/100"),
+            ("DELETE", "https://proxmox:123/api2/json/nodes/proxmox/qemu/100"),
         )
-        self.proxmox.nodes("proxmox").openvz("101").delete()
+        self.proxmox.nodes("proxmox").qemu("101").delete()
         eq_(
             self.session.request.call_args[0],
-            ("DELETE", "https://proxmox:123/api2/json/nodes/proxmox/openvz/101"),
+            ("DELETE", "https://proxmox:123/api2/json/nodes/proxmox/qemu/101"),
         )
 
     def test_post(self):
         node = self.proxmox.nodes("proxmox")
-        node.openvz.create(
+        node.qemu.create(
             vmid=800,
             ostemplate="local:vztmpl/debian-6-turnkey-core_12.0-1_i386.tar.gz",
             hostname="test",
@@ -172,7 +172,7 @@ class TestSuite:
         )
         eq_(
             self.session.request.call_args[0],
-            ("POST", "https://proxmox:123/api2/json/nodes/proxmox/openvz"),
+            ("POST", "https://proxmox:123/api2/json/nodes/proxmox/qemu"),
         )
         ok_("data" in self.session.request.call_args[1])
         data = self.session.request.call_args[1]["data"]
@@ -188,7 +188,7 @@ class TestSuite:
         eq_(data["vmid"], 800)
 
         node = self.proxmox.nodes("proxmox1")
-        node.openvz.post(
+        node.qemu.post(
             vmid=900,
             ostemplate="local:vztmpl/debian-7-turnkey-core_12.0-1_i386.tar.gz",
             hostname="test1",
@@ -202,7 +202,7 @@ class TestSuite:
         )
         eq_(
             self.session.request.call_args[0],
-            ("POST", "https://proxmox:123/api2/json/nodes/proxmox1/openvz"),
+            ("POST", "https://proxmox:123/api2/json/nodes/proxmox1/qemu"),
         )
         ok_("data" in self.session.request.call_args[1])
         data = self.session.request.call_args[1]["data"]
@@ -219,10 +219,10 @@ class TestSuite:
 
     def test_put(self):
         node = self.proxmox.nodes("proxmox")
-        node.openvz(101).config.set(cpus=4, memory=1024, ip_address="10.0.100.100", onboot=True)
+        node.qemu(101).config.set(cpus=4, memory=1024, ip_address="10.0.100.100", onboot=True)
         eq_(
             self.session.request.call_args[0],
-            ("PUT", "https://proxmox:123/api2/json/nodes/proxmox/openvz/101/config"),
+            ("PUT", "https://proxmox:123/api2/json/nodes/proxmox/qemu/101/config"),
         )
         data = self.session.request.call_args[1]["data"]
         eq_(data["cpus"], 4)
@@ -231,10 +231,10 @@ class TestSuite:
         eq_(data["onboot"], True)
 
         node = self.proxmox.nodes("proxmox1")
-        node.openvz(102).config.put(cpus=2, memory=512, ip_address="10.0.100.200", onboot=False)
+        node.qemu(102).config.put(cpus=2, memory=512, ip_address="10.0.100.200", onboot=False)
         eq_(
             self.session.request.call_args[0],
-            ("PUT", "https://proxmox:123/api2/json/nodes/proxmox1/openvz/102/config"),
+            ("PUT", "https://proxmox:123/api2/json/nodes/proxmox1/qemu/102/config"),
         )
         data = self.session.request.call_args[1]["data"]
         eq_(data["cpus"], 2)


### PR DESCRIPTION
All backends now correctly support passing commands with arguments to the Qemu guest agent to execute.
The commands can also be passed as strings or arrays.
They are ultimately exec'ed, not run in a shell, so wrapping in e.g. "bash -c 'COMMAND'" might be needed.

The alteration of the `command` argument is only applied to the `.../agent/exec` endpoint as to not interfere with other endpoints which also have a `command` argument.

fixes #89 