### PR TITLE
fix error handling for APIs that don't give a dict in the response

### DIFF
--- a/proxmoxer/backends/https.py
+++ b/proxmoxer/backends/https.py
@@ -159,7 +159,7 @@ class JsonSerializer(object):
     def loads_errors(self, response):
         try:
             return json.loads(response.text)["errors"]
-        except (UnicodeDecodeError, ValueError):
+        except (UnicodeDecodeError, ValueError, KeyError):
             return {"errors": response.content}
 
 

--- a/proxmoxer/backends/https.py
+++ b/proxmoxer/backends/https.py
@@ -158,8 +158,8 @@ class JsonSerializer(object):
 
     def loads_errors(self, response):
         try:
-            return json.loads(response.text)["errors"]
-        except (UnicodeDecodeError, ValueError, KeyError):
+            return json.loads(response.text).get("errors")
+        except (UnicodeDecodeError, ValueError):
             return {"errors": response.content}
 
 

--- a/proxmoxer/core.py
+++ b/proxmoxer/core.py
@@ -126,7 +126,7 @@ class ProxmoxResource(ProxmoxResourceBase):
                         resp.status_code, ANYEVENT_HTTP_STATUS_CODES.get(resp.status_code)
                     ),
                     resp.reason,
-                    errors=(self._store["serializer"].loads_errors(resp) or {}),
+                    errors=(self._store["serializer"].loads_errors(resp)),
                 )
             else:
                 raise ResourceException(


### PR DESCRIPTION
addresses https://github.com/proxmoxer/proxmoxer/issues/96

before
```
...
    print(client.nodes(node_id).storage("local").status.get())
  File "/usr/local/lib/python3.8/dist-packages/proxmoxer/core.py", line 143, in get
    return self(args)._request("GET", params=params)
  File "/usr/local/lib/python3.8/dist-packages/proxmoxer/core.py", line 129, in _request
    errors=(self._store["serializer"].loads_errors(resp) or {}),
  File "/usr/local/lib/python3.8/dist-packages/proxmoxer/backends/https.py", line 181, in loads_errors
    return json.loads(response.text)["errors"]
KeyError: 'errors'
```

now
```
...
    print(client.nodes(node_id).storage("local").status.get())
  File "/usr/local/lib/python3.8/dist-packages/proxmoxer/core.py", line 143, in get
    return self(args)._request("GET", params=params)
  File "/usr/local/lib/python3.8/dist-packages/proxmoxer/core.py", line 123, in _request
    raise ResourceException(
proxmoxer.core.ResourceException: 403 Forbidden: Permission check failed (/storage/local, Datastore.Audit|Datastore.AllocateSpace) - {'errors': b'{"data":null}'}
```