### PR TITLE
Allow specifying resource_id as 0 for firewall rule compatibility

### DIFF
--- a/proxmoxer/core.py
+++ b/proxmoxer/core.py
@@ -93,7 +93,7 @@ class ProxmoxResource(object):
         return urlparse.urlunsplit([scheme, netloc, path, query, fragment])
 
     def __call__(self, resource_id=None):
-        if not resource_id:
+        if resource_id in (None, ''):
             return self
 
         if isinstance(resource_id, basestring):


### PR DESCRIPTION
E.g. `proxmox.nodes(node_id).qemu(vm_id).firewall.rules(rule_pos)` can use `rule_pos = 0` which is treated as False (unset) and therefore as unset `resource_id`. 

This change keeps treating empty strings as a non-specified id for backwards compatibility reasons, but checking `if resource_id is None` is probably more correct.

A workaround for earlier versions is to cast pos to a `str(rule_pos)` before calling `.rules(rule_pos)`