### PR TITLE
Remove `None` values from request params and data (Fixes #119)

### DIFF
--- a/proxmoxer/core.py
+++ b/proxmoxer/core.py
@@ -93,7 +93,7 @@ class ProxmoxResource(object):
         return urlparse.urlunsplit([scheme, netloc, path, query, fragment])
 
     def __call__(self, resource_id=None):
-        if resource_id in (None, ''):
+        if resource_id in (None, ""):
             return self
 
         if isinstance(resource_id, basestring):
@@ -113,6 +113,21 @@ class ProxmoxResource(object):
             logger.info("%s %s %r", method, url, data)
         else:
             logger.info("%s %s", method, url)
+
+        # passing None values to pvesh command breaks it, let's remove them just as requests library does
+        # helpful when dealing with function default values higher in the chain, no need to clean up in multiple places
+        if params:
+            # remove keys that are set to None
+            params_none_keys = [k for (k, v) in params.items() if v is None]
+            for key in params_none_keys:
+                del params[key]
+
+        if data:
+            # remove keys that are set to None
+            data_none_keys = [k for (k, v) in data.items() if v is None]
+            for key in data_none_keys:
+                del data[key]
+
         resp = self._store["session"].request(method, url, data=data, params=params)
         logger.debug("Status code: %s, output: %s", resp.status_code, resp.content)
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -196,6 +196,16 @@ class TestProxmoxResource:
         assert exc_info.value.content == "this is the reason"
         assert exc_info.value.errors == {"errors": b"this is the error"}
 
+    def test_request_params_cleanup(self, mock_resource):
+        mock_resource._request("GET", params={"key": "value", "remove_me": None})
+
+        assert mock_resource._store["session"].params == {"key": "value"}
+
+    def test_request_data_cleanup(self, mock_resource):
+        mock_resource._request("POST", data={"key": "value", "remove_me": None})
+
+        assert mock_resource._store["session"].data == {"key": "value"}
+
 
 class TestProxmoxResourceMethods:
     _resource = core.ProxmoxResource(base_url="https://example.com")


### PR DESCRIPTION
In addition to cleaning up params and data, as discussed in #119 fixed data integrity checks as well.
I can separate the data integrity check fix to a separate PR if needed.