### PR TITLE
FIX: HTTPS Token Auth verify_ssl propagation

### DIFF
--- a/proxmoxer/backends/https.py
+++ b/proxmoxer/backends/https.py
@@ -287,7 +287,14 @@ class Backend:
             if "token" not in SERVICES[service]["supported_https_auths"]:
                 config_failure("{} does not support API Token authentication", service)
 
-            self.auth = ProxmoxHTTPApiTokenAuth(user, token_name, token_value, service=service)
+            self.auth = ProxmoxHTTPApiTokenAuth(
+                user,
+                token_name,
+                token_value,
+                verify_ssl=verify_ssl,
+                timeout=timeout,
+                service=service
+            )
         elif password is not None:
             if "password" not in SERVICES[service]["supported_https_auths"]:
                 config_failure("{} does not support password authentication", service)

--- a/proxmoxer/backends/https.py
+++ b/proxmoxer/backends/https.py
@@ -293,7 +293,7 @@ class Backend:
                 token_value,
                 verify_ssl=verify_ssl,
                 timeout=timeout,
-                service=service
+                service=service,
             )
         elif password is not None:
             if "password" not in SERVICES[service]["supported_https_auths"]:

--- a/tests/test_https.py
+++ b/tests/test_https.py
@@ -108,6 +108,22 @@ class TestHttpsBackend:
 
         assert ("ticket", "CSRFPreventionToken") == backend.get_tokens()
 
+    def test_verify_ssl_token(self):
+        backend = https.Backend("1.2.3.4:1234", token_name="name")
+        assert backend.auth.verify_ssl is True
+
+    def test_verify_ssl_false_token(self):
+        backend = https.Backend("1.2.3.4:1234", token_name="name", verify_ssl=False)
+        assert backend.auth.verify_ssl is False
+
+    def test_verify_ssl_password(self, mock_pve):
+        backend = https.Backend("1.2.3.4:1234", password="name")
+        assert backend.auth.verify_ssl is True
+
+    def test_verify_ssl_false_password(self, mock_pve):
+        backend = https.Backend("1.2.3.4:1234", password="name", verify_ssl=False)
+        assert backend.auth.verify_ssl is False
+
 
 class TestProxmoxHTTPAuthBase:
     """


### PR DESCRIPTION
I discovered a bug in the https backend code for token auth. The `verify_ssl` arg was not passed correctly to the auth backend (and so was the `timeout` arg). I fixed this and implemented some checks to protect against this error for the future.

FYI this bug produced the folowing output at "normal" requests with correct SSL-Certificates on a proxmox host:
```python
from proxmoxer import ProxmoxAPI
proxmox = ProxmoxAPI('proxmox-1.example.com user='demo@pve', token_name='demo', token_value='redacted', verify_ssl=True)
proxmox.nodes.get()
/Users/dominik/code/virtualenvs/proxmox-utils-vBjC0H-5-py3.10/lib/python3.10/site-packages/urllib3/connectionpool.py:1045: InsecureRequestWarning: Unverified HTTPS request is being made to host 'proxmox-1.example.com'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/1.26.x/advanced-usage.html#ssl-warnings
  warnings.warn(
[{'ssl_fingerprint': 'redacted', 'id': 'node/proxmox-1', 'node': 'proxmox-1', 'level': '', 'status': 'online', 'type': 'node'}]
```