### PR TITLE
Update Readme with updated example

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -76,8 +76,8 @@ API calls using the access methods above.
 .. code-block:: pycon
 
     >>> for node in proxmox.nodes.get():
-    ...     for vm in proxmox.nodes(node["node"]).openvz.get():
-    ...         print "{0}. {1} => {2}".format(vm["vmid"], vm["name"], vm["status"])
+    ...     for vm in proxmox.nodes(node["node"]).qemu.get():
+    ...         print(f"{vm['vmid']}. {vm['name']} => {vm['status']}")
     ...
 
     141. puppet-2.london.example.com => running


### PR DESCRIPTION
The API for accessing VM information has changed from openvz to qemu (https://pve.proxmox.com/pve-docs/api-viewer/index.html#/nodes/{node}/qemu). This change updates to reflect that change and updates the print statement to the python 3 syntax and f-strings.