### PR TITLE
Fix improper spliting of non-exec QEMU commands

### DIFF
--- a/proxmoxer/backends/https.py
+++ b/proxmoxer/backends/https.py
@@ -194,7 +194,7 @@ class ProxmoxHttpSession(requests.Session):
         total_file_size = 0
         for k, v in data.copy().items():
             # split qemu exec commands for proper parsing by PVE (issue#89)
-            if k == "command":
+            if k == "command" and url.endswith("agent/exec"):
                 if isinstance(v, list):
                     data[k] = v
                 elif "Windows" not in platform.platform():

--- a/tests/api_mock.py
+++ b/tests/api_mock.py
@@ -333,8 +333,6 @@ class PVERegistry(responses.registries.FirstMatchRegistry):
     def _cb_qemu_monitor(self, request):
         body = request.body
         if body is not None:
-            if isinstance(body, MultipartEncoder):
-                body = body.to_string()  # really, to byte string
             body = body if isinstance(body, str) else str(body, "utf-8")
 
         # if the command is an array, throw the type error PVE would throw

--- a/tests/api_mock.py
+++ b/tests/api_mock.py
@@ -103,6 +103,22 @@ class PVERegistry(responses.registries.FirstMatchRegistry):
         resps.append(
             responses.CallbackResponse(
                 method="GET",
+                url=re.compile(self.base_url + r"/nodes/[^/]+/qemu/[^/]+/agent/exec"),
+                callback=self._cb_echo,
+            )
+        )
+
+        resps.append(
+            responses.CallbackResponse(
+                method="GET",
+                url=re.compile(self.base_url + r"/nodes/[^/]+/qemu/[^/]+/monitor"),
+                callback=self._cb_qemu_monitor,
+            )
+        )
+
+        resps.append(
+            responses.CallbackResponse(
+                method="GET",
                 url=re.compile(self.base_url + r"/nodes/[^/]+/tasks/[^/]+/status"),
                 callback=self._cb_task_status,
             )
@@ -313,3 +329,34 @@ class PVERegistry(responses.registries.FirstMatchRegistry):
                     }
                 ),
             )
+
+    def _cb_qemu_monitor(self, request):
+        body = request.body
+        if body is not None:
+            if isinstance(body, MultipartEncoder):
+                body = body.to_string()  # really, to byte string
+            body = body if isinstance(body, str) else str(body, "utf-8")
+
+        # if the command is an array, throw the type error PVE would throw
+        if "&" in body:
+            return (
+                400,
+                self.common_headers,
+                json.dumps(
+                    {
+                        "data": None,
+                        "errors": {"command": "type check ('string') failed - got ARRAY"},
+                    }
+                ),
+            )
+        else:
+            resp = {
+                "method": request.method,
+                "url": request.url,
+                "headers": dict(request.headers),
+                "cookies": request._cookies.get_dict(),
+                "body": body,
+                # "body_json": dict(parse_qsl(request.body)),
+            }
+            print(resp)
+            return (200, self.common_headers, json.dumps(resp))

--- a/tests/test_https.py
+++ b/tests/test_https.py
@@ -291,25 +291,51 @@ class TestProxmoxHttpSession:
         assert content["body"] == "key=value"
         assert content["headers"]["Content-Type"] == "application/x-www-form-urlencoded"
 
-    def test_request_command_list(self, mock_pve):
+    def test_request_monitor_command_list(self, mock_pve):
         resp = self._session.request(
-            "GET", self.base_url + "/fake/echo", data={"command": ["echo", "hello", "world"]}
+            "GET",
+            self.base_url + "/nodes/node_name/qemu/100/monitor",
+            data={"command": ["info", "block"]},
+        )
+
+        assert resp.status_code == 400
+
+    def test_request_exec_command_list(self, mock_pve):
+        resp = self._session.request(
+            "GET",
+            self.base_url + "/nodes/node_name/qemu/100/agent/exec",
+            data={"command": ["echo", "hello", "world"]},
         )
         content = resp.json()
 
         assert content["method"] == "GET"
-        assert content["url"] == self.base_url + "/fake/echo"
+        assert content["url"] == self.base_url + "/nodes/node_name/qemu/100/agent/exec"
         assert content["body"] == "command=echo&command=hello&command=world"
         assert content["headers"]["Content-Type"] == "application/x-www-form-urlencoded"
 
-    def test_request_command_string(self, mock_pve):
+    def test_request_monitor_command_string(self, mock_pve):
         resp = self._session.request(
-            "GET", self.base_url + "/fake/echo", data={"command": "echo hello world"}
+            "GET",
+            self.base_url + "/nodes/node_name/qemu/100/monitor",
+            data={"command": "echo hello world"},
         )
         content = resp.json()
 
         assert content["method"] == "GET"
-        assert content["url"] == self.base_url + "/fake/echo"
+        assert content["url"] == self.base_url + "/nodes/node_name/qemu/100/monitor"
+        assert content["body"] == "command=echo+hello+world"
+        assert content["headers"]["Content-Type"] == "application/x-www-form-urlencoded"
+
+    def test_request_exec_command_string(self, mock_pve):
+        resp = self._session.request(
+            "GET",
+            self.base_url + "/nodes/node_name/qemu/100/agent/exec",
+            data={"command": "echo hello world"},
+        )
+        content = resp.json()
+
+        assert content["method"] == "GET"
+        assert content["url"] == self.base_url + "/nodes/node_name/qemu/100/agent/exec"
         assert content["body"] == "command=echo&command=hello&command=world"
         assert content["headers"]["Content-Type"] == "application/x-www-form-urlencoded"
 


### PR DESCRIPTION
Only split a string into an array for the [`/qemu/{vmid}/agent/exec` endpoint](https://pve.proxmox.com/pve-docs/api-viewer/index.html#/nodes/{node}/qemu/{vmid}/agent/exec). Spliting other `command` key/value pairs breaks other QEMU endpoints e.g. [`/qemu/{vmid}/monitor`](https://pve.proxmox.com/pve-docs/api-viewer/index.html#/nodes/{node}/qemu/{vmid}/monitor)

Fixes: #161