### PR TITLE
Fix wrong URL with backend local #176 

### DIFF
--- a/proxmoxer/backends/local.py
+++ b/proxmoxer/backends/local.py
@@ -22,4 +22,4 @@ class LocalSession(CommandBaseSession):
 class Backend(CommandBaseBackend):
     def __init__(self, *args, **kwargs):
         self.session = LocalSession(*args, **kwargs)
-        self.target = "localhost"
+        self.target = "/"


### PR DESCRIPTION
Fix #176: the URL for local backend is `/` not `localhost`.