### PR TITLE
Add support to pass in an optional cert/tuple that is used in the con…

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -336,6 +336,40 @@ class TestProxmoxAPI:
         assert ticket is None
         assert csrf is None
 
+    def test_init_with_cert(self):
+        prox = core.ProxmoxAPI(
+            "host",
+            token_name="name",
+            token_value="value",
+            service="pVe",
+            backend="hTtPs",
+            cert="somepem",
+        )
+
+        assert isinstance(prox, core.ProxmoxAPI)
+        assert isinstance(prox, core.ProxmoxResource)
+        assert isinstance(prox._backend, https.Backend)
+        assert prox._backend.auth.service == "PVE"
+        assert prox._backend.cert == "somepem"
+        assert prox._store["session"].cert == "somepem"
+
+    def test_init_with_cert_key(self):
+        prox = core.ProxmoxAPI(
+            "host",
+            token_name="name",
+            token_value="value",
+            service="pVe",
+            backend="hTtPs",
+            cert=("somepem", "somekey"),
+        )
+
+        assert isinstance(prox, core.ProxmoxAPI)
+        assert isinstance(prox, core.ProxmoxResource)
+        assert isinstance(prox._backend, https.Backend)
+        assert prox._backend.auth.service == "PVE"
+        assert prox._backend.cert == ("somepem", "somekey")
+        assert prox._store["session"].cert == ("somepem", "somekey")
+
 
 class MockSession:
     def request(self, method, url, data=None, params=None):

--- a/tests/test_https.py
+++ b/tests/test_https.py
@@ -276,6 +276,7 @@ class TestProxmoxHttpSession:
     def test_request_basic(self, mock_pve):
         resp = self._session.request("GET", self.base_url + "/fake/echo")
         content = resp.json()
+        assert self._session.cert is None
 
         assert content["method"] == "GET"
         assert content["url"] == self.base_url + "/fake/echo"


### PR DESCRIPTION
…nection to proxmox. Usecase: proxmox is behind a service like teleport where it proxies the connection using local certificates after you login.