### PR TITLE
Fix commandline backends prefixing with host

### DIFF
--- a/proxmoxer/backends/command_base.py
+++ b/proxmoxer/backends/command_base.py
@@ -147,13 +147,13 @@ class JsonSimpleSerializer:
 class CommandBaseBackend:
     def __init__(self):
         self.session = None
-        self.target = ""
+        self.target = None
 
     def get_session(self):
         return self.session
 
     def get_base_url(self):
-        return self.target
+        return ""
 
     def get_serializer(self):
         return JsonSimpleSerializer()

--- a/proxmoxer/core.py
+++ b/proxmoxer/core.py
@@ -217,7 +217,8 @@ class ProxmoxAPI(ProxmoxResource):
         }
 
     def __repr__(self):
-        return f"ProxmoxAPI ({self._backend_name} backend for {self._store['base_url']})"
+        dest = getattr(self._backend, "target", self._store.get("base_url"))
+        return f"ProxmoxAPI ({self._backend_name} backend for {dest})"
 
     def get_tokens(self):
         """Return the auth and csrf tokens.

--- a/tests/test_command_base.py
+++ b/tests/test_command_base.py
@@ -213,7 +213,7 @@ class TestCommandBaseBackend:
         b = command_base.CommandBaseBackend()
 
         assert b.session is None
-        assert b.target == ""
+        assert b.target is None
 
     def test_get_session(self):
         assert self.backend.get_session() == self.sess


### PR DESCRIPTION
fix commandline-based backends (local and SSH backends) not functioning due to the hostname/IP being added to the start of the request path.

Fixes: #170 
builds on # 186