### PR TITLE
Release v2.2.0

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -13,7 +13,7 @@
   ],
   "[python]": {
     "editor.codeActionsOnSave": {
-      "source.organizeImports": true
+      "source.organizeImports": "explicit"
     }
   },
   "cSpell.words": [

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -99,7 +99,7 @@
     {
       "label": "Clean Cache/tmp files",
       "type": "shell",
-      "command": "rm -rf ./.mypy_cache/ ./.pytest_cache/ ./coverage.xml ./.coverage",
+      "command": "rm -rf ./.mypy_cache/ ./.pytest_cache/ ./dist/ ./coverage.xml ./.coverage README.txt",
       "problemMatcher": [],
       "group": {
         "kind": "none"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 2.2.0 (2024-12-13)
+
+* Bugfix (local,openssh,paramiko): Remove IP/hostname from command path ([Andrea Dainese](https://github.com/dainok), [John Hollowell](https://github.com/jhollowe))
+* Addition (https): Allow passing certificate for TLS verification ([gdelaneync](https://github.com/gdelaneync))
+* Bugfix (local,openssh,paramiko): Prevent a returned task ID (UPID) from throwing an error ([Adam Dorsey](https://github.com/asdorsey), [John Hollowell](https://github.com/jhollowe))
+* Improvement (local,openssh,paramiko): Attempt to encode binary payloads as UTF-8 before sending/JSON-ing ([Adam Dorsey](https://github.com/asdorsey))
+
 ## 2.1.0 (2024-08-10)
 
 * Improvement (docs): Update Readme with updated example ([Rob Wolinski](https://github.com/trekie86))
@@ -7,7 +14,7 @@
 * Bugfix (https): Fix BytesWarning when logging response status/content ([Walter Doekes](https://github.com/wdoekes))
 * Improvement (meta): Update devcontainer to modern unified schema ([John Hollowell](https://github.com/jhollowe))
 * Improvement (meta): Add 3.12 to CI matrix, remove 3.7 testing ([John Hollowell](https://github.com/jhollowe))
-* Improvement (all): Fix improper spliting of non-exec QEMU commands ([John Hollowell](https://github.com/jhollowe))
+* Improvement (all): Fix improper splitting of non-exec QEMU commands ([John Hollowell](https://github.com/jhollowe))
 
 ## 2.0.1 (2022-12-19)
 
@@ -42,7 +49,7 @@
 * Improvement (command_base): Refactor code to have a unified CLI backend base for `openssh`, `ssh_paramiko`, and `local` backends ([Markus Reiter](https://github.com/reitermarkus))
 * Improvement (https): Support IPv6 addresses ([Daviddcc](https://github.com/dcasier))
 * Improvement: Move CI to GitHub actions from Travis.ci ([John Hollowell](https://github.com/jhollowe))
-* Improvement: Cleanup documentaiton and move to dedicated site ([John Hollowell](https://github.com/jhollowe))
+* Improvement: Cleanup documentation and move to dedicated site ([John Hollowell](https://github.com/jhollowe))
 * Improvement: Add `pre-commit` hooks for formatting and linting and format all code ([John Hollowell](https://github.com/jhollowe))
 
 ## 1.2.0 (2021-10-07)
@@ -77,7 +84,7 @@
 * Improvement (https): Added option to specify port in hostname parameter ([pvanagtmaal](https://github.com/pvanagtmaal))
 * Improvement: Added stderr to the Response content ([Jérôme Schneider](https://github.com/merinos))
 * Bugfix (ssh_paramiko): Paramiko python3: stdout and stderr must be a str not bytes ([Jérôme Schneider](https://github.com/merinos))
-* New lxc example in docu ([Geert Stappers](https://github.com/stappersg))
+* New lxc example in documentation ([Geert Stappers](https://github.com/stappersg))
 
 ## 1.0.2 (2017-12-02)
 * Tarball repackaged with tests

--- a/proxmoxer/__init__.py
+++ b/proxmoxer/__init__.py
@@ -1,6 +1,6 @@
 __author__ = "Oleg Butovich"
-__copyright__ = "(c) Oleg Butovich 2013-2017"
-__version__ = "2.1.0"
+__copyright__ = "(c) Oleg Butovich 2013-2024"
+__version__ = "2.2.0"
 __license__ = "MIT"
 
 from .core import *  # noqa

--- a/proxmoxer/backends/command_base.py
+++ b/proxmoxer/backends/command_base.py
@@ -147,13 +147,13 @@ class JsonSimpleSerializer:
 class CommandBaseBackend:
     def __init__(self):
         self.session = None
-        self.target = ""
+        self.target = None
 
     def get_session(self):
         return self.session
 
     def get_base_url(self):
-        return self.target
+        return ""
 
     def get_serializer(self):
         return JsonSimpleSerializer()

--- a/proxmoxer/backends/command_base.py
+++ b/proxmoxer/backends/command_base.py
@@ -88,7 +88,12 @@ class CommandBaseSession:
 
         command = [f"{self.service}sh", cmd, url]
         # convert the options dict into a 2-tuple with the key formatted as a flag
-        option_pairs = [(f"-{k}", str(v)) for k, v in chain(data.items(), params.items())]
+        option_pairs = []
+        for k, v in chain(data.items(), params.items()):
+            try:
+                option_pairs.append((f"-{k}", str(v, "utf-8")))
+            except TypeError:
+                option_pairs.append((f"-{k}", str(v)))
         # add back in all the command arguments as their own pairs
         if data_command is not None:
             if isinstance(data_command, list):

--- a/proxmoxer/backends/command_base.py
+++ b/proxmoxer/backends/command_base.py
@@ -111,15 +111,22 @@ class CommandBaseSession:
             return re.match(r"\d\d\d [a-zA-Z]", str(s))
 
         if stderr:
-            # sometimes contains extra text like 'trying to acquire lock...OK'
-            status_code = next(
-                (
-                    int(line.split()[0])
-                    for line in stderr.splitlines()
-                    if is_http_status_string(line)
-                ),
-                500,
+            # assume if we got a task ID that the request was successful
+            task_id_pattern = re.compile(
+                r"UPID:[\w-]+:[0-9a-fA-F]{8}:[0-9a-fA-F]{8}:[0-9a-fA-F]{8}:\w+:[\w\._-]+:[\w\.@_-]+:\w*"
             )
+            if task_id_pattern.search(str(stdout)) or task_id_pattern.search(str(stderr)):
+                status_code = 200
+            else:
+                # sometimes contains extra text like 'trying to acquire lock...OK'
+                status_code = next(
+                    (
+                        int(line.split()[0])
+                        for line in stderr.splitlines()
+                        if is_http_status_string(line)
+                    ),
+                    500,
+                )
         else:
             status_code = 200
         if stdout:

--- a/proxmoxer/backends/local.py
+++ b/proxmoxer/backends/local.py
@@ -22,4 +22,4 @@ class LocalSession(CommandBaseSession):
 class Backend(CommandBaseBackend):
     def __init__(self, *args, **kwargs):
         self.session = LocalSession(*args, **kwargs)
-        self.target = "/"
+        self.target = "localhost"

--- a/proxmoxer/core.py
+++ b/proxmoxer/core.py
@@ -217,7 +217,8 @@ class ProxmoxAPI(ProxmoxResource):
         }
 
     def __repr__(self):
-        return f"ProxmoxAPI ({self._backend_name} backend for {self._store['base_url']})"
+        dest = getattr(self._backend, "target", self._store.get("base_url"))
+        return f"ProxmoxAPI ({self._backend_name} backend for {dest})"
 
     def get_tokens(self):
         """Return the auth and csrf tokens.

--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,8 @@ setup(
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
         "Programming Language :: Python :: 3",
         "Programming Language :: Python",
         "Topic :: Software Development :: Libraries :: Python Modules",

--- a/tests/test_command_base.py
+++ b/tests/test_command_base.py
@@ -213,7 +213,7 @@ class TestCommandBaseBackend:
         b = command_base.CommandBaseBackend()
 
         assert b.session is None
-        assert b.target == ""
+        assert b.target is None
 
     def test_get_session(self):
         assert self.backend.get_session() == self.sess

--- a/tests/test_command_base.py
+++ b/tests/test_command_base.py
@@ -122,6 +122,22 @@ class TestCommandBaseSession:
             "json",
         ]
 
+    def test_request_bytes_data(self, mock_exec):
+        resp = self._session.request(
+            "GET", self.base_url + "/fake/echo", data={"key": b"bytes-value"}
+        )
+
+        assert resp.status_code == 200
+        assert resp.content == [
+            "pvesh",
+            "get",
+            self.base_url + "/fake/echo",
+            "-key",
+            "bytes-value",
+            "--output-format",
+            "json",
+        ]
+
     def test_request_qemu_exec(self, mock_exec):
         resp = self._session.request(
             "POST",

--- a/tests/test_command_base.py
+++ b/tests/test_command_base.py
@@ -56,6 +56,23 @@ class TestCommandBaseSession:
             "json",
         ]
 
+    def test_request_task(self, mock_exec_task):
+        resp = self._session.request("GET", self.base_url + "/stdout")
+
+        assert resp.status_code == 200
+        assert (
+            resp.content == "UPID:node:003094EA:095F1EFE:63E88772:download:file.iso:root@pam:done"
+        )
+
+        resp_stderr = self._session.request("GET", self.base_url + "/stderr")
+
+        assert resp_stderr.status_code == 200
+        assert (
+            resp_stderr.content
+            == "UPID:node:003094EA:095F1EFE:63E88772:download:file.iso:root@pam:done"
+        )
+        # assert False  # DEBUG
+
     def test_request_error(self, mock_exec_err):
         resp = self._session.request(
             "GET", self.base_url + "/fake/echo", data={"thing": "403 Unauthorized"}
@@ -243,6 +260,15 @@ def _exec_err(_, cmd):
 
 
 @classmethod
+def _exec_task(_, cmd):
+    upid = "UPID:node:003094EA:095F1EFE:63E88772:download:file.iso:root@pam:done"
+    if "stderr" in cmd[2]:
+        return None, upid
+    else:
+        return upid, None
+
+
+@classmethod
 def upload_file_obj_echo(_, file_obj, remote_path):
     return file_obj, remote_path
 
@@ -258,6 +284,12 @@ def mock_upload_file_obj():
 @pytest.fixture
 def mock_exec():
     with mock.patch.object(command_base.CommandBaseSession, "_exec", _exec_echo):
+        yield
+
+
+@pytest.fixture
+def mock_exec_task():
+    with mock.patch.object(command_base.CommandBaseSession, "_exec", _exec_task):
         yield
 
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -310,7 +310,7 @@ class TestProxmoxAPI:
     def test_repr_local(self):
         prox = core.ProxmoxAPI(backend="local")
 
-        assert repr(prox) == "ProxmoxAPI (local backend for /)"
+        assert repr(prox) == "ProxmoxAPI (local backend for localhost)"
 
     def test_repr_openssh(self):
         prox = core.ProxmoxAPI("host", user="user", backend="openssh")

--- a/tests/test_local.py
+++ b/tests/test_local.py
@@ -14,7 +14,7 @@ class TestLocalBackend:
         back = local.Backend()
 
         assert isinstance(back.session, local.LocalSession)
-        assert back.target == "/"
+        assert back.target == "localhost"
 
 
 class TestLocalSession:


### PR DESCRIPTION
* Bugfix (local,openssh,paramiko): Remove IP/hostname from command path ([Andrea Dainese](https://github.com/dainok), [John Hollowell](https://github.com/jhollowe))
* Addition (https): Allow passing certificate for TLS verification ([gdelaneync](https://github.com/gdelaneync))
* Bugfix (local,openssh,paramiko): Prevent a returned task ID (UPID) from throwing an error ([Adam Dorsey](https://github.com/asdorsey), [John Hollowell](https://github.com/jhollowe))
* Improvement (local,openssh,paramiko): Attempt to encode binary payloads as UTF-8 before sending/JSON-ing ([Adam Dorsey](https://github.com/asdorsey))