### PR TITLE
Add workaround for broken `pvesh` output.

### DIFF
--- a/proxmoxer/backends/command_base.py
+++ b/proxmoxer/backends/command_base.py
@@ -145,10 +145,24 @@ class CommandBaseSession:
 
 class JsonSimpleSerializer:
     def loads(self, response):
+        # FIXME: Workaround for https://bugzilla.proxmox.com/show_bug.cgi?id=4333.
+        #
+        # With each iteration, try parsing one fewer line, until
+        # we reach the beginning of the actual JSON message.
         try:
-            return json.loads(response.content)
-        except (UnicodeDecodeError, ValueError):
-            return {"errors": response.content}
+            content = response.content
+            if isinstance(content, bytes):
+                content = content.decode("utf-8")
+            content_lines = content.splitlines()
+            while content_lines:
+                try:
+                    return json.loads("\n".join(content_lines))
+                except ValueError:
+                    content_lines = content_lines[1:]
+        except UnicodeDecodeError:
+            pass
+
+        return {"errors": response.content}
 
     def loads_errors(self, response):
         try:

--- a/tests/test_command_base.py
+++ b/tests/test_command_base.py
@@ -247,6 +247,19 @@ class TestJsonSimpleSerializer:
 
         assert act_output == exp_output
 
+    def test_loads_json_preceded_by_non_json(self):
+        input_str = """
+        virtio0: successfully created disk 'local-zfs:vm-7777-disk-0,discard=on,iothread=1,size=4G'
+        "UPID:net2-pve:002605B4:00FB48C2:62B9E7EB:qmcreate:7777:root@pam:"
+        """
+        exp_output = "UPID:net2-pve:002605B4:00FB48C2:62B9E7EB:qmcreate:7777:root@pam:"
+
+        response = command_base.Response(input_str.encode("utf-8"), 200, 201)
+
+        act_output = self._serializer.loads(response)
+
+        assert act_output == exp_output
+
 
 class TestCommandBaseBackend:
     backend = command_base.CommandBaseBackend()


### PR DESCRIPTION
Seeing as https://github.com/ansible-collections/community.general/pull/4027 is still not merged after over 3 years because https://bugzilla.proxmox.com/show_bug.cgi?id=4333 still isn't fixed, I'd suggest adding this more generic workaround here rather than the very specific one in https://github.com/ansible-collections/community.general/pull/4027.

Basically, `pvesh` can contain random output before the JSON message, so try parsing one fewer line with each try, until we reach the end of the output.

Seems like I actually suggested this 3 years ago: https://github.com/proxmoxer/proxmoxer/issues/117#issuecomment-1329343479