### PR TITLE
Add possibility to use proxy with https backend

### DIFF
--- a/proxmoxer/backends/https.py
+++ b/proxmoxer/backends/https.py
@@ -267,7 +267,9 @@ class Backend:
         path_prefix=None,
         service="PVE",
         cert=None,
+        proxies=None,
     ):
+        self.proxies = proxies
         self.cert = cert
         host_port = ""
         if len(host.split(":")) > 2:  # IPv6
@@ -327,6 +329,8 @@ class Backend:
         # cookies are taken from the auth
         session.headers["Connection"] = "keep-alive"
         session.headers["accept"] = self.get_serializer().get_accept_types()
+        if self.proxies:
+            session.proxies.update(self.proxies)
         return session
 
     def get_base_url(self):

--- a/proxmoxer/backends/https.py
+++ b/proxmoxer/backends/https.py
@@ -42,11 +42,12 @@ class ProxmoxHTTPAuthBase(AuthBase):
     def get_tokens(self):
         return None, None
 
-    def __init__(self, timeout=5, service="PVE", verify_ssl=False, cert=None):
+    def __init__(self, timeout=5, service="PVE", verify_ssl=False, cert=None, proxies=None):
         self.timeout = timeout
         self.service = service
         self.verify_ssl = verify_ssl
         self.cert = cert
+        self.proxies = proxies
 
 
 class ProxmoxHTTPAuth(ProxmoxHTTPAuthBase):
@@ -77,6 +78,7 @@ class ProxmoxHTTPAuth(ProxmoxHTTPAuthBase):
             timeout=self.timeout,
             data=data,
             cert=self.cert,
+            proxies=self.proxies,
         ).json()["data"]
         if response_data is None:
             raise AuthenticationError(
@@ -304,6 +306,7 @@ class Backend:
                 timeout=timeout,
                 service=service,
                 cert=self.cert,
+                proxies=proxies,
             )
         elif password is not None:
             if "password" not in SERVICES[service]["supported_https_auths"]:
@@ -318,6 +321,7 @@ class Backend:
                 timeout=timeout,
                 service=service,
                 cert=self.cert,
+                proxies=proxies,
             )
         else:
             config_failure("No valid authentication credentials were supplied")

--- a/tests/test_https.py
+++ b/tests/test_https.py
@@ -36,7 +36,17 @@ class TestHttpsBackend:
         with pytest.raises(NotImplementedError) as exc_info:
             https.Backend("1.2.3.4:1234")
 
-        assert str(exc_info.value) == "No valid authentication credentials were supplied"
+        assert (
+            str(exc_info.value)
+            == "No valid authentication credentials were supplied"
+        )
+
+    def test_init_with_proxy(self):
+        proxy_url = "http://proxy.example.com:8080"
+        backend = https.Backend("1.2.3.4:1234", token_name="", proxy=proxy_url)
+
+        session = backend.get_session()
+        assert session.proxies == {"http": proxy_url, "https": proxy_url}
 
     def test_init_ip4_separate_port(self):
         backend = https.Backend("1.2.3.4", port=1234, token_name="")
@@ -57,7 +67,9 @@ class TestHttpsBackend:
         assert backend.get_base_url() == exp_base_url
 
     def test_init_ip6_brackets_separate_port(self):
-        backend = https.Backend("[2001:0db8::1:2:3:4]", port=1234, token_name="")
+        backend = https.Backend(
+            "[2001:0db8::1:2:3:4]", port=1234, token_name=""
+        )
         exp_base_url = "https://[2001:0db8::1:2:3:4]:1234/api2/json"
 
         assert backend.get_base_url() == exp_base_url
@@ -75,7 +87,9 @@ class TestHttpsBackend:
         assert backend.get_base_url() == exp_base_url
 
     def test_init_path_prefix(self):
-        backend = https.Backend("1.2.3.4:1234", path_prefix="path", token_name="")
+        backend = https.Backend(
+            "1.2.3.4:1234", path_prefix="path", token_name=""
+        )
         exp_base_url = "https://1.2.3.4:1234/path/api2/json"
 
         assert backend.get_base_url() == exp_base_url
@@ -89,13 +103,19 @@ class TestHttpsBackend:
         with pytest.raises(NotImplementedError) as exc_info:
             https.Backend("1.2.3.4:1234", token_name="name", service="NONE")
 
-        assert str(exc_info.value) == "NONE does not support API Token authentication"
+        assert (
+            str(exc_info.value)
+            == "NONE does not support API Token authentication"
+        )
 
     def test_init_password_not_supported(self, apply_none_service):
         with pytest.raises(NotImplementedError) as exc_info:
             https.Backend("1.2.3.4:1234", password="pass", service="NONE")
 
-        assert str(exc_info.value) == "NONE does not support password authentication"
+        assert (
+            str(exc_info.value)
+            == "NONE does not support password authentication"
+        )
 
     def test_get_tokens_api_token(self):
         backend = https.Backend("1.2.3.4:1234", token_name="name")
@@ -112,7 +132,9 @@ class TestHttpsBackend:
         assert backend.auth.verify_ssl is True
 
     def test_verify_ssl_false_token(self):
-        backend = https.Backend("1.2.3.4:1234", token_name="name", verify_ssl=False)
+        backend = https.Backend(
+            "1.2.3.4:1234", token_name="name", verify_ssl=False
+        )
         assert backend.auth.verify_ssl is False
 
     def test_verify_ssl_password(self, mock_pve):
@@ -120,7 +142,9 @@ class TestHttpsBackend:
         assert backend.auth.verify_ssl is True
 
     def test_verify_ssl_false_password(self, mock_pve):
-        backend = https.Backend("1.2.3.4:1234", password="name", verify_ssl=False)
+        backend = https.Backend(
+            "1.2.3.4:1234", password="name", verify_ssl=False
+        )
         assert backend.auth.verify_ssl is False
 
 
@@ -132,7 +156,9 @@ class TestProxmoxHTTPAuthBase:
     base_url = PVERegistry.base_url
 
     def test_init_all_args(self):
-        auth = https.ProxmoxHTTPAuthBase(timeout=1234, service="PMG", verify_ssl=True)
+        auth = https.ProxmoxHTTPAuthBase(
+            timeout=1234, service="PMG", verify_ssl=True
+        )
 
         assert auth.timeout == 1234
         assert auth.service == "PMG"
@@ -160,7 +186,12 @@ class TestProxmoxHTTPApiTokenAuth:
 
     def test_init_all_args(self):
         auth = https.ProxmoxHTTPApiTokenAuth(
-            "user", "name", "value", service="PMG", timeout=1234, verify_ssl=True
+            "user",
+            "name",
+            "value",
+            service="PMG",
+            timeout=1234,
+            verify_ssl=True,
         )
 
         assert auth.username == "user"
@@ -171,14 +202,18 @@ class TestProxmoxHTTPApiTokenAuth:
         assert auth.verify_ssl is True
 
     def test_call_pve(self):
-        auth = https.ProxmoxHTTPApiTokenAuth("user", "name", "value", service="PVE")
+        auth = https.ProxmoxHTTPApiTokenAuth(
+            "user", "name", "value", service="PVE"
+        )
         req = Request("HEAD", self.base_url + "/version").prepare()
         resp = auth(req)
 
         assert resp.headers["Authorization"] == "PVEAPIToken=user!name=value"
 
     def test_call_pbs(self):
-        auth = https.ProxmoxHTTPApiTokenAuth("user", "name", "value", service="PBS")
+        auth = https.ProxmoxHTTPApiTokenAuth(
+            "user", "name", "value", service="PBS"
+        )
         req = Request("HEAD", self.base_url + "/version").prepare()
         resp = auth(req)
 
@@ -229,7 +264,9 @@ class TestProxmoxHTTPAuth:
         assert auth.csrf_prevention_token == "CSRFPreventionToken_2"
 
     def test_get_cookies(self, mock_pve):
-        auth = https.ProxmoxHTTPAuth("user", "password", base_url=self.base_url, service="PVE")
+        auth = https.ProxmoxHTTPAuth(
+            "user", "password", base_url=self.base_url, service="PVE"
+        )
 
         assert auth.get_cookies().get_dict() == {"PVEAuthCookie": "ticket"}
 
@@ -248,12 +285,18 @@ class TestProxmoxHTTPAuth:
 
     def test_auth_otp(self, mock_pve):
         https.ProxmoxHTTPAuth(
-            "otp", "password", base_url=self.base_url, otp="123456", service="PVE"
+            "otp",
+            "password",
+            base_url=self.base_url,
+            otp="123456",
+            service="PVE",
         )
 
     def test_auth_otp_missing(self, mock_pve):
         with pytest.raises(core.AuthenticationError) as exc_info:
-            https.ProxmoxHTTPAuth("otp", "password", base_url=self.base_url, service="PVE")
+            https.ProxmoxHTTPAuth(
+                "otp", "password", base_url=self.base_url, service="PVE"
+            )
 
         assert (
             str(exc_info.value)
@@ -281,16 +324,24 @@ class TestProxmoxHttpSession:
         assert content["method"] == "GET"
         assert content["url"] == self.base_url + "/fake/echo"
         assert content["body"] is None
-        assert content["headers"]["accept"] == https.JsonSerializer().get_accept_types()
+        assert (
+            content["headers"]["accept"]
+            == https.JsonSerializer().get_accept_types()
+        )
 
     def test_request_data(self, mock_pve):
-        resp = self._session.request("GET", self.base_url + "/fake/echo", data={"key": "value"})
+        resp = self._session.request(
+            "GET", self.base_url + "/fake/echo", data={"key": "value"}
+        )
         content = resp.json()
 
         assert content["method"] == "GET"
         assert content["url"] == self.base_url + "/fake/echo"
         assert content["body"] == "key=value"
-        assert content["headers"]["Content-Type"] == "application/x-www-form-urlencoded"
+        assert (
+            content["headers"]["Content-Type"]
+            == "application/x-www-form-urlencoded"
+        )
 
     def test_request_monitor_command_list(self, mock_pve):
         resp = self._session.request(
@@ -310,9 +361,15 @@ class TestProxmoxHttpSession:
         content = resp.json()
 
         assert content["method"] == "GET"
-        assert content["url"] == self.base_url + "/nodes/node_name/qemu/100/agent/exec"
+        assert (
+            content["url"]
+            == self.base_url + "/nodes/node_name/qemu/100/agent/exec"
+        )
         assert content["body"] == "command=echo&command=hello&command=world"
-        assert content["headers"]["Content-Type"] == "application/x-www-form-urlencoded"
+        assert (
+            content["headers"]["Content-Type"]
+            == "application/x-www-form-urlencoded"
+        )
 
     def test_request_monitor_command_string(self, mock_pve):
         resp = self._session.request(
@@ -323,9 +380,15 @@ class TestProxmoxHttpSession:
         content = resp.json()
 
         assert content["method"] == "GET"
-        assert content["url"] == self.base_url + "/nodes/node_name/qemu/100/monitor"
+        assert (
+            content["url"]
+            == self.base_url + "/nodes/node_name/qemu/100/monitor"
+        )
         assert content["body"] == "command=echo+hello+world"
-        assert content["headers"]["Content-Type"] == "application/x-www-form-urlencoded"
+        assert (
+            content["headers"]["Content-Type"]
+            == "application/x-www-form-urlencoded"
+        )
 
     def test_request_exec_command_string(self, mock_pve):
         resp = self._session.request(
@@ -336,9 +399,15 @@ class TestProxmoxHttpSession:
         content = resp.json()
 
         assert content["method"] == "GET"
-        assert content["url"] == self.base_url + "/nodes/node_name/qemu/100/agent/exec"
+        assert (
+            content["url"]
+            == self.base_url + "/nodes/node_name/qemu/100/agent/exec"
+        )
         assert content["body"] == "command=echo&command=hello&command=world"
-        assert content["headers"]["Content-Type"] == "application/x-www-form-urlencoded"
+        assert (
+            content["headers"]["Content-Type"]
+            == "application/x-www-form-urlencoded"
+        )
 
     def test_request_file(self, mock_pve):
         size = 10
@@ -346,7 +415,9 @@ class TestProxmoxHttpSession:
         with tempfile.TemporaryFile("w+b") as f_obj:
             f_obj.write(b"a" * size)
             f_obj.seek(0)
-            resp = self._session.request("GET", self.base_url + "/fake/echo", data={"iso": f_obj})
+            resp = self._session.request(
+                "GET", self.base_url + "/fake/echo", data={"iso": f_obj}
+            )
             content = resp.json()
 
         # decode multipart file
@@ -356,9 +427,14 @@ class TestProxmoxHttpSession:
         assert content["method"] == "GET"
         assert content["url"] == self.base_url + "/fake/echo"
         assert m is not None  # content matches multipart for the created file
-        assert content["headers"]["Content-Type"] == "multipart/form-data; boundary=" + m[1]
+        assert (
+            content["headers"]["Content-Type"]
+            == "multipart/form-data; boundary=" + m[1]
+        )
 
-    def test_request_streaming(self, shrink_thresholds, toolbelt_on_off, caplog, mock_pve):
+    def test_request_streaming(
+        self, shrink_thresholds, toolbelt_on_off, caplog, mock_pve
+    ):
         caplog.set_level(logging.INFO, logger=MODULE_LOGGER_NAME)
 
         size = https.STREAMING_SIZE_THRESHOLD + 1
@@ -366,7 +442,9 @@ class TestProxmoxHttpSession:
         with tempfile.TemporaryFile("w+b") as f_obj:
             f_obj.write(b"a" * size)
             f_obj.seek(0)
-            resp = self._session.request("GET", self.base_url + "/fake/echo", data={"iso": f_obj})
+            resp = self._session.request(
+                "GET", self.base_url + "/fake/echo", data={"iso": f_obj}
+            )
             content = resp.json()
 
         # decode multipart file
@@ -376,7 +454,10 @@ class TestProxmoxHttpSession:
         assert content["method"] == "GET"
         assert content["url"] == self.base_url + "/fake/echo"
         assert m is not None  # content matches multipart for the created file
-        assert content["headers"]["Content-Type"] == "multipart/form-data; boundary=" + m[1]
+        assert (
+            content["headers"]["Content-Type"]
+            == "multipart/form-data; boundary=" + m[1]
+        )
 
         if not toolbelt_on_off:
             assert caplog.record_tuples == [
@@ -387,7 +468,9 @@ class TestProxmoxHttpSession:
                 )
             ]
 
-    def test_request_large_file(self, shrink_thresholds, toolbelt_on_off, caplog, mock_pve):
+    def test_request_large_file(
+        self, shrink_thresholds, toolbelt_on_off, caplog, mock_pve
+    ):
         size = https.SSL_OVERFLOW_THRESHOLD + 1
         content = {}
         with tempfile.TemporaryFile("w+b") as f_obj:
@@ -406,8 +489,13 @@ class TestProxmoxHttpSession:
 
                 assert content["method"] == "GET"
                 assert content["url"] == self.base_url + "/fake/echo"
-                assert m is not None  # content matches multipart for the created file
-                assert content["headers"]["Content-Type"] == "multipart/form-data; boundary=" + m[1]
+                assert (
+                    m is not None
+                )  # content matches multipart for the created file
+                assert (
+                    content["headers"]["Content-Type"]
+                    == "multipart/form-data; boundary=" + m[1]
+                )
 
             else:
                 # forcing an ImportError
@@ -416,7 +504,10 @@ class TestProxmoxHttpSession:
                         "GET", self.base_url + "/fake/echo", data={"iso": f_obj}
                     )
 
-                assert str(exc_info.value) == "Unable to upload a payload larger than 2 GiB"
+                assert (
+                    str(exc_info.value)
+                    == "Unable to upload a payload larger than 2 GiB"
+                )
                 assert caplog.record_tuples == [
                     (
                         MODULE_LOGGER_NAME,
@@ -441,7 +532,10 @@ class TestProxmoxHttpSession:
         assert content["method"] == "GET"
         assert content["url"] == self.base_url + "/fake/echo"
         assert m is not None  # content matches multipart for the created file
-        assert content["headers"]["Content-Type"] == "multipart/form-data; boundary=" + m[1]
+        assert (
+            content["headers"]["Content-Type"]
+            == "multipart/form-data; boundary=" + m[1]
+        )
 
 
 # pylint: disable=protected-access
@@ -453,7 +547,9 @@ class TestJsonSerializer:
         assert ctypes == self._serializer.get_accept_types()
 
     def test_loads_pass(self):
-        input_str = '{"data": {"key1": "value1", "key2": "value2"}, "errors": {}}'
+        input_str = (
+            '{"data": {"key1": "value1", "key2": "value2"}, "errors": {}}'
+        )
         exp_output = {"key1": "value1", "key2": "value2"}
 
         response = Response()
@@ -475,7 +571,9 @@ class TestJsonSerializer:
         assert act_output == exp_output
 
     def test_loads_not_unicode(self):
-        input_str = '{"data": {"key1": "value1", "key2": "value2"}, "errors": {}}\x80'
+        input_str = (
+            '{"data": {"key1": "value1", "key2": "value2"}, "errors": {}}\x80'
+        )
         exp_output = {"errors": input_str.encode("utf-8")}
 
         response = Response()
@@ -486,9 +584,7 @@ class TestJsonSerializer:
         assert act_output == exp_output
 
     def test_loads_errors_pass(self):
-        input_str = (
-            '{"data": {}, "errors": ["missing required param 1", "missing required param 2"]}'
-        )
+        input_str = '{"data": {}, "errors": ["missing required param 1", "missing required param 2"]}'
         exp_output = ["missing required param 1", "missing required param 2"]
 
         response = Response()
@@ -499,9 +595,7 @@ class TestJsonSerializer:
         assert act_output == exp_output
 
     def test_loads_errors_not_json(self):
-        input_str = (
-            '{"data": {} "errors": ["missing required param 1", "missing required param 2"]}'
-        )
+        input_str = '{"data": {} "errors": ["missing required param 1", "missing required param 2"]}'
         exp_output = {
             "errors": b'{"data": {} "errors": ["missing required param 1", "missing required param 2"]}'
         }
@@ -514,9 +608,7 @@ class TestJsonSerializer:
         assert act_output == exp_output
 
     def test_loads_errors_not_unicode(self):
-        input_str = (
-            '{"data": {}, "errors": ["missing required param 1", "missing required param 2"]}\x80'
-        )
+        input_str = '{"data": {}, "errors": ["missing required param 1", "missing required param 2"]}\x80'
         exp_output = {"errors": input_str.encode("utf-8")}
 
         response = Response()
@@ -541,8 +633,9 @@ def toolbelt_on_off(request, monkeypatch):
 
 @pytest.fixture
 def shrink_thresholds():
-    with mock.patch("proxmoxer.backends.https.STREAMING_SIZE_THRESHOLD", 100), mock.patch(
-        "proxmoxer.backends.https.SSL_OVERFLOW_THRESHOLD", 1000
+    with (
+        mock.patch("proxmoxer.backends.https.STREAMING_SIZE_THRESHOLD", 100),
+        mock.patch("proxmoxer.backends.https.SSL_OVERFLOW_THRESHOLD", 1000),
     ):
         yield
 
@@ -557,7 +650,8 @@ def apply_none_service():
         }
     }
 
-    with mock.patch("proxmoxer.core.SERVICES", serv), mock.patch(
-        "proxmoxer.backends.https.SERVICES", serv
+    with (
+        mock.patch("proxmoxer.core.SERVICES", serv),
+        mock.patch("proxmoxer.backends.https.SERVICES", serv),
     ):
         yield

--- a/tests/test_https.py
+++ b/tests/test_https.py
@@ -36,10 +36,7 @@ class TestHttpsBackend:
         with pytest.raises(NotImplementedError) as exc_info:
             https.Backend("1.2.3.4:1234")
 
-        assert (
-            str(exc_info.value)
-            == "No valid authentication credentials were supplied"
-        )
+        assert str(exc_info.value) == "No valid authentication credentials were supplied"
 
     def test_init_with_proxy(self):
         proxy_url = "http://proxy.example.com:8080"
@@ -67,9 +64,7 @@ class TestHttpsBackend:
         assert backend.get_base_url() == exp_base_url
 
     def test_init_ip6_brackets_separate_port(self):
-        backend = https.Backend(
-            "[2001:0db8::1:2:3:4]", port=1234, token_name=""
-        )
+        backend = https.Backend("[2001:0db8::1:2:3:4]", port=1234, token_name="")
         exp_base_url = "https://[2001:0db8::1:2:3:4]:1234/api2/json"
 
         assert backend.get_base_url() == exp_base_url
@@ -87,9 +82,7 @@ class TestHttpsBackend:
         assert backend.get_base_url() == exp_base_url
 
     def test_init_path_prefix(self):
-        backend = https.Backend(
-            "1.2.3.4:1234", path_prefix="path", token_name=""
-        )
+        backend = https.Backend("1.2.3.4:1234", path_prefix="path", token_name="")
         exp_base_url = "https://1.2.3.4:1234/path/api2/json"
 
         assert backend.get_base_url() == exp_base_url
@@ -103,19 +96,13 @@ class TestHttpsBackend:
         with pytest.raises(NotImplementedError) as exc_info:
             https.Backend("1.2.3.4:1234", token_name="name", service="NONE")
 
-        assert (
-            str(exc_info.value)
-            == "NONE does not support API Token authentication"
-        )
+        assert str(exc_info.value) == "NONE does not support API Token authentication"
 
     def test_init_password_not_supported(self, apply_none_service):
         with pytest.raises(NotImplementedError) as exc_info:
             https.Backend("1.2.3.4:1234", password="pass", service="NONE")
 
-        assert (
-            str(exc_info.value)
-            == "NONE does not support password authentication"
-        )
+        assert str(exc_info.value) == "NONE does not support password authentication"
 
     def test_get_tokens_api_token(self):
         backend = https.Backend("1.2.3.4:1234", token_name="name")
@@ -132,9 +119,7 @@ class TestHttpsBackend:
         assert backend.auth.verify_ssl is True
 
     def test_verify_ssl_false_token(self):
-        backend = https.Backend(
-            "1.2.3.4:1234", token_name="name", verify_ssl=False
-        )
+        backend = https.Backend("1.2.3.4:1234", token_name="name", verify_ssl=False)
         assert backend.auth.verify_ssl is False
 
     def test_verify_ssl_password(self, mock_pve):
@@ -142,9 +127,7 @@ class TestHttpsBackend:
         assert backend.auth.verify_ssl is True
 
     def test_verify_ssl_false_password(self, mock_pve):
-        backend = https.Backend(
-            "1.2.3.4:1234", password="name", verify_ssl=False
-        )
+        backend = https.Backend("1.2.3.4:1234", password="name", verify_ssl=False)
         assert backend.auth.verify_ssl is False
 
 
@@ -156,9 +139,7 @@ class TestProxmoxHTTPAuthBase:
     base_url = PVERegistry.base_url
 
     def test_init_all_args(self):
-        auth = https.ProxmoxHTTPAuthBase(
-            timeout=1234, service="PMG", verify_ssl=True
-        )
+        auth = https.ProxmoxHTTPAuthBase(timeout=1234, service="PMG", verify_ssl=True)
 
         assert auth.timeout == 1234
         assert auth.service == "PMG"
@@ -186,12 +167,7 @@ class TestProxmoxHTTPApiTokenAuth:
 
     def test_init_all_args(self):
         auth = https.ProxmoxHTTPApiTokenAuth(
-            "user",
-            "name",
-            "value",
-            service="PMG",
-            timeout=1234,
-            verify_ssl=True,
+            "user", "name", "value", service="PMG", timeout=1234, verify_ssl=True
         )
 
         assert auth.username == "user"
@@ -202,18 +178,14 @@ class TestProxmoxHTTPApiTokenAuth:
         assert auth.verify_ssl is True
 
     def test_call_pve(self):
-        auth = https.ProxmoxHTTPApiTokenAuth(
-            "user", "name", "value", service="PVE"
-        )
+        auth = https.ProxmoxHTTPApiTokenAuth("user", "name", "value", service="PVE")
         req = Request("HEAD", self.base_url + "/version").prepare()
         resp = auth(req)
 
         assert resp.headers["Authorization"] == "PVEAPIToken=user!name=value"
 
     def test_call_pbs(self):
-        auth = https.ProxmoxHTTPApiTokenAuth(
-            "user", "name", "value", service="PBS"
-        )
+        auth = https.ProxmoxHTTPApiTokenAuth("user", "name", "value", service="PBS")
         req = Request("HEAD", self.base_url + "/version").prepare()
         resp = auth(req)
 
@@ -264,9 +236,7 @@ class TestProxmoxHTTPAuth:
         assert auth.csrf_prevention_token == "CSRFPreventionToken_2"
 
     def test_get_cookies(self, mock_pve):
-        auth = https.ProxmoxHTTPAuth(
-            "user", "password", base_url=self.base_url, service="PVE"
-        )
+        auth = https.ProxmoxHTTPAuth("user", "password", base_url=self.base_url, service="PVE")
 
         assert auth.get_cookies().get_dict() == {"PVEAuthCookie": "ticket"}
 
@@ -285,18 +255,12 @@ class TestProxmoxHTTPAuth:
 
     def test_auth_otp(self, mock_pve):
         https.ProxmoxHTTPAuth(
-            "otp",
-            "password",
-            base_url=self.base_url,
-            otp="123456",
-            service="PVE",
+            "otp", "password", base_url=self.base_url, otp="123456", service="PVE"
         )
 
     def test_auth_otp_missing(self, mock_pve):
         with pytest.raises(core.AuthenticationError) as exc_info:
-            https.ProxmoxHTTPAuth(
-                "otp", "password", base_url=self.base_url, service="PVE"
-            )
+            https.ProxmoxHTTPAuth("otp", "password", base_url=self.base_url, service="PVE")
 
         assert (
             str(exc_info.value)
@@ -324,24 +288,16 @@ class TestProxmoxHttpSession:
         assert content["method"] == "GET"
         assert content["url"] == self.base_url + "/fake/echo"
         assert content["body"] is None
-        assert (
-            content["headers"]["accept"]
-            == https.JsonSerializer().get_accept_types()
-        )
+        assert content["headers"]["accept"] == https.JsonSerializer().get_accept_types()
 
     def test_request_data(self, mock_pve):
-        resp = self._session.request(
-            "GET", self.base_url + "/fake/echo", data={"key": "value"}
-        )
+        resp = self._session.request("GET", self.base_url + "/fake/echo", data={"key": "value"})
         content = resp.json()
 
         assert content["method"] == "GET"
         assert content["url"] == self.base_url + "/fake/echo"
         assert content["body"] == "key=value"
-        assert (
-            content["headers"]["Content-Type"]
-            == "application/x-www-form-urlencoded"
-        )
+        assert content["headers"]["Content-Type"] == "application/x-www-form-urlencoded"
 
     def test_request_monitor_command_list(self, mock_pve):
         resp = self._session.request(
@@ -361,15 +317,9 @@ class TestProxmoxHttpSession:
         content = resp.json()
 
         assert content["method"] == "GET"
-        assert (
-            content["url"]
-            == self.base_url + "/nodes/node_name/qemu/100/agent/exec"
-        )
+        assert content["url"] == self.base_url + "/nodes/node_name/qemu/100/agent/exec"
         assert content["body"] == "command=echo&command=hello&command=world"
-        assert (
-            content["headers"]["Content-Type"]
-            == "application/x-www-form-urlencoded"
-        )
+        assert content["headers"]["Content-Type"] == "application/x-www-form-urlencoded"
 
     def test_request_monitor_command_string(self, mock_pve):
         resp = self._session.request(
@@ -380,15 +330,9 @@ class TestProxmoxHttpSession:
         content = resp.json()
 
         assert content["method"] == "GET"
-        assert (
-            content["url"]
-            == self.base_url + "/nodes/node_name/qemu/100/monitor"
-        )
+        assert content["url"] == self.base_url + "/nodes/node_name/qemu/100/monitor"
         assert content["body"] == "command=echo+hello+world"
-        assert (
-            content["headers"]["Content-Type"]
-            == "application/x-www-form-urlencoded"
-        )
+        assert content["headers"]["Content-Type"] == "application/x-www-form-urlencoded"
 
     def test_request_exec_command_string(self, mock_pve):
         resp = self._session.request(
@@ -399,15 +343,9 @@ class TestProxmoxHttpSession:
         content = resp.json()
 
         assert content["method"] == "GET"
-        assert (
-            content["url"]
-            == self.base_url + "/nodes/node_name/qemu/100/agent/exec"
-        )
+        assert content["url"] == self.base_url + "/nodes/node_name/qemu/100/agent/exec"
         assert content["body"] == "command=echo&command=hello&command=world"
-        assert (
-            content["headers"]["Content-Type"]
-            == "application/x-www-form-urlencoded"
-        )
+        assert content["headers"]["Content-Type"] == "application/x-www-form-urlencoded"
 
     def test_request_file(self, mock_pve):
         size = 10
@@ -415,9 +353,7 @@ class TestProxmoxHttpSession:
         with tempfile.TemporaryFile("w+b") as f_obj:
             f_obj.write(b"a" * size)
             f_obj.seek(0)
-            resp = self._session.request(
-                "GET", self.base_url + "/fake/echo", data={"iso": f_obj}
-            )
+            resp = self._session.request("GET", self.base_url + "/fake/echo", data={"iso": f_obj})
             content = resp.json()
 
         # decode multipart file
@@ -427,14 +363,9 @@ class TestProxmoxHttpSession:
         assert content["method"] == "GET"
         assert content["url"] == self.base_url + "/fake/echo"
         assert m is not None  # content matches multipart for the created file
-        assert (
-            content["headers"]["Content-Type"]
-            == "multipart/form-data; boundary=" + m[1]
-        )
+        assert content["headers"]["Content-Type"] == "multipart/form-data; boundary=" + m[1]
 
-    def test_request_streaming(
-        self, shrink_thresholds, toolbelt_on_off, caplog, mock_pve
-    ):
+    def test_request_streaming(self, shrink_thresholds, toolbelt_on_off, caplog, mock_pve):
         caplog.set_level(logging.INFO, logger=MODULE_LOGGER_NAME)
 
         size = https.STREAMING_SIZE_THRESHOLD + 1
@@ -442,9 +373,7 @@ class TestProxmoxHttpSession:
         with tempfile.TemporaryFile("w+b") as f_obj:
             f_obj.write(b"a" * size)
             f_obj.seek(0)
-            resp = self._session.request(
-                "GET", self.base_url + "/fake/echo", data={"iso": f_obj}
-            )
+            resp = self._session.request("GET", self.base_url + "/fake/echo", data={"iso": f_obj})
             content = resp.json()
 
         # decode multipart file
@@ -454,10 +383,7 @@ class TestProxmoxHttpSession:
         assert content["method"] == "GET"
         assert content["url"] == self.base_url + "/fake/echo"
         assert m is not None  # content matches multipart for the created file
-        assert (
-            content["headers"]["Content-Type"]
-            == "multipart/form-data; boundary=" + m[1]
-        )
+        assert content["headers"]["Content-Type"] == "multipart/form-data; boundary=" + m[1]
 
         if not toolbelt_on_off:
             assert caplog.record_tuples == [
@@ -468,9 +394,7 @@ class TestProxmoxHttpSession:
                 )
             ]
 
-    def test_request_large_file(
-        self, shrink_thresholds, toolbelt_on_off, caplog, mock_pve
-    ):
+    def test_request_large_file(self, shrink_thresholds, toolbelt_on_off, caplog, mock_pve):
         size = https.SSL_OVERFLOW_THRESHOLD + 1
         content = {}
         with tempfile.TemporaryFile("w+b") as f_obj:
@@ -489,13 +413,8 @@ class TestProxmoxHttpSession:
 
                 assert content["method"] == "GET"
                 assert content["url"] == self.base_url + "/fake/echo"
-                assert (
-                    m is not None
-                )  # content matches multipart for the created file
-                assert (
-                    content["headers"]["Content-Type"]
-                    == "multipart/form-data; boundary=" + m[1]
-                )
+                assert m is not None  # content matches multipart for the created file
+                assert content["headers"]["Content-Type"] == "multipart/form-data; boundary=" + m[1]
 
             else:
                 # forcing an ImportError
@@ -504,10 +423,7 @@ class TestProxmoxHttpSession:
                         "GET", self.base_url + "/fake/echo", data={"iso": f_obj}
                     )
 
-                assert (
-                    str(exc_info.value)
-                    == "Unable to upload a payload larger than 2 GiB"
-                )
+                assert str(exc_info.value) == "Unable to upload a payload larger than 2 GiB"
                 assert caplog.record_tuples == [
                     (
                         MODULE_LOGGER_NAME,
@@ -532,10 +448,7 @@ class TestProxmoxHttpSession:
         assert content["method"] == "GET"
         assert content["url"] == self.base_url + "/fake/echo"
         assert m is not None  # content matches multipart for the created file
-        assert (
-            content["headers"]["Content-Type"]
-            == "multipart/form-data; boundary=" + m[1]
-        )
+        assert content["headers"]["Content-Type"] == "multipart/form-data; boundary=" + m[1]
 
 
 # pylint: disable=protected-access
@@ -547,9 +460,7 @@ class TestJsonSerializer:
         assert ctypes == self._serializer.get_accept_types()
 
     def test_loads_pass(self):
-        input_str = (
-            '{"data": {"key1": "value1", "key2": "value2"}, "errors": {}}'
-        )
+        input_str = '{"data": {"key1": "value1", "key2": "value2"}, "errors": {}}'
         exp_output = {"key1": "value1", "key2": "value2"}
 
         response = Response()
@@ -571,9 +482,7 @@ class TestJsonSerializer:
         assert act_output == exp_output
 
     def test_loads_not_unicode(self):
-        input_str = (
-            '{"data": {"key1": "value1", "key2": "value2"}, "errors": {}}\x80'
-        )
+        input_str = '{"data": {"key1": "value1", "key2": "value2"}, "errors": {}}\x80'
         exp_output = {"errors": input_str.encode("utf-8")}
 
         response = Response()
@@ -584,7 +493,9 @@ class TestJsonSerializer:
         assert act_output == exp_output
 
     def test_loads_errors_pass(self):
-        input_str = '{"data": {}, "errors": ["missing required param 1", "missing required param 2"]}'
+        input_str = (
+            '{"data": {}, "errors": ["missing required param 1", "missing required param 2"]}'
+        )
         exp_output = ["missing required param 1", "missing required param 2"]
 
         response = Response()
@@ -595,7 +506,9 @@ class TestJsonSerializer:
         assert act_output == exp_output
 
     def test_loads_errors_not_json(self):
-        input_str = '{"data": {} "errors": ["missing required param 1", "missing required param 2"]}'
+        input_str = (
+            '{"data": {} "errors": ["missing required param 1", "missing required param 2"]}'
+        )
         exp_output = {
             "errors": b'{"data": {} "errors": ["missing required param 1", "missing required param 2"]}'
         }
@@ -608,7 +521,9 @@ class TestJsonSerializer:
         assert act_output == exp_output
 
     def test_loads_errors_not_unicode(self):
-        input_str = '{"data": {}, "errors": ["missing required param 1", "missing required param 2"]}\x80'
+        input_str = (
+            '{"data": {}, "errors": ["missing required param 1", "missing required param 2"]}\x80'
+        )
         exp_output = {"errors": input_str.encode("utf-8")}
 
         response = Response()
@@ -633,9 +548,8 @@ def toolbelt_on_off(request, monkeypatch):
 
 @pytest.fixture
 def shrink_thresholds():
-    with (
-        mock.patch("proxmoxer.backends.https.STREAMING_SIZE_THRESHOLD", 100),
-        mock.patch("proxmoxer.backends.https.SSL_OVERFLOW_THRESHOLD", 1000),
+    with mock.patch("proxmoxer.backends.https.STREAMING_SIZE_THRESHOLD", 100), mock.patch(
+        "proxmoxer.backends.https.SSL_OVERFLOW_THRESHOLD", 1000
     ):
         yield
 
@@ -650,8 +564,7 @@ def apply_none_service():
         }
     }
 
-    with (
-        mock.patch("proxmoxer.core.SERVICES", serv),
-        mock.patch("proxmoxer.backends.https.SERVICES", serv),
+    with mock.patch("proxmoxer.core.SERVICES", serv), mock.patch(
+        "proxmoxer.backends.https.SERVICES", serv
     ):
         yield

--- a/tests/test_https.py
+++ b/tests/test_https.py
@@ -40,10 +40,11 @@ class TestHttpsBackend:
 
     def test_init_with_proxy(self):
         proxy_url = "http://proxy.example.com:8080"
-        backend = https.Backend("1.2.3.4:1234", token_name="", proxy=proxy_url)
+        proxies = {"http": proxy_url, "https": proxy_url}
+        backend = https.Backend("1.2.3.4:1234", token_name="", proxies=proxies)
 
         session = backend.get_session()
-        assert session.proxies == {"http": proxy_url, "https": proxy_url}
+        assert session.proxies == proxies
 
     def test_init_ip4_separate_port(self):
         backend = https.Backend("1.2.3.4", port=1234, token_name="")


### PR DESCRIPTION
Usage:
```
        socks_proxy = "socks5h://127.0.0.1:9000"
        proxies = {
            "http": socks_proxy,
            "https": socks_proxy,
        }
        proxmox = proxmoxer.ProxmoxAPI(
            host="proxmox.net",
            user=username",
            password=password,
            port=443,
            verify_ssl=False,
            timeout=5,
            proxies=proxies,
        )
```