### PR TITLE
fix: use exit_code as fallback for status code when no HTTP status pa…

### DIFF
--- a/proxmoxer/backends/command_base.py
+++ b/proxmoxer/backends/command_base.py
@@ -131,7 +131,7 @@ class CommandBaseSession:
                         for line in stderr.splitlines()
                         if is_http_status_string(line)
                     ),
-                    500,
+                    200 if exit_code == 0 else 500,
                 )
         else:
             status_code = 200

--- a/tests/test_command_base.py
+++ b/tests/test_command_base.py
@@ -99,6 +99,19 @@ class TestCommandBaseSession:
             == "pvesh\nget\nhttps://1.2.3.4:1234/api2/json/fake/echo\n-thing\nfailure\n--output-format\njson"
         )
 
+    def test_request_stderr_non_status_exit0(self, mock_exec_stderr_non_status):
+        resp = self._session.request("GET", self.base_url + "/fake/echo")
+
+        assert resp.status_code == 200
+        assert resp.exit_code == 0
+        assert resp.content == '{"data": "ok"}'
+
+    def test_request_stderr_non_status_exit_nonzero(self, mock_exec_stderr_non_status_fail):
+        resp = self._session.request("GET", self.base_url + "/fake/echo")
+
+        assert resp.status_code == 500
+        assert resp.exit_code == 1
+
     def test_request_sudo(self, mock_exec):
         resp = command_base.CommandBaseSession(sudo=True).request(
             "GET", self.base_url + "/fake/echo"
@@ -334,7 +347,29 @@ def mock_exec_task():
         yield
 
 
+@classmethod
+def _exec_stderr_non_status(_, cmd):
+    return '{"data": "ok"}', "some non-http-status warning", 0
+
+
+@classmethod
+def _exec_stderr_non_status_fail(_, cmd):
+    return None, "some non-http-status warning", 1
+
+
 @pytest.fixture
 def mock_exec_err():
     with mock.patch.object(command_base.CommandBaseSession, "_exec", _exec_err):
+        yield
+
+
+@pytest.fixture
+def mock_exec_stderr_non_status():
+    with mock.patch.object(command_base.CommandBaseSession, "_exec", _exec_stderr_non_status):
+        yield
+
+
+@pytest.fixture
+def mock_exec_stderr_non_status_fail():
+    with mock.patch.object(command_base.CommandBaseSession, "_exec", _exec_stderr_non_status_fail):
         yield


### PR DESCRIPTION
On PVE 9, pvesh emits plugin warnings to stderr (e.g. "Plugin ... is implementing an older storage API"), which don't match the \d\d\d [a-zA-Z] status pattern. This causes the hardcoded 500 default to trigger for every API call, even though exit code is 0 and stdout contains valid JSON.

The exit_code is already propagated from _exec() since 2.3.0 but was never used for status code determination. Use it: 200 if exit_code == 0, else 500.

Fix proposed for issue #222 !