### PR TITLE
ci: pin workflow actions to immutable SHAs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,15 +24,15 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: ${{ matrix.python-version }}
 
       - name: Cache PIP packages
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-python${{ matrix.python-version }}-${{ hashFiles('*requirements.txt') }}


### PR DESCRIPTION
## Summary
- pin the floating CI workflow actions to immutable commit SHAs
- keep the patch scoped to `.github/workflows/ci.yaml`
- preserve existing job behavior and matrix coverage

## Why
GitHub recommends pinning third-party actions to full-length SHAs to reduce workflow supply-chain risk from mutable tags.

## Validation
- `git diff --check`
- `python -c "import pathlib, yaml; p=pathlib.Path(r'.github/workflows/ci.yaml'); yaml.safe_load(p.read_text(encoding='utf-8')); print('yaml_ok', p)"`

## Notes
- leaves already version-pinned `pre-commit/action@v3.0.1` and `coverallsapp/github-action@v2.3.4` unchanged
- no workflow logic changes
