### PR TITLE
Add PDM support with HTTPS backend and corresponding tests

### DIFF
--- a/proxmoxer/core.py
+++ b/proxmoxer/core.py
@@ -42,6 +42,12 @@ SERVICES = {
         "default_port": 8007,
         "token_separator": ":",
     },
+    "PDM": {
+        "supported_backends": ["https"],
+        "supported_https_auths": ["password", "token"],
+        "default_port": 8443,
+        "token_separator": ":",
+    }
 }
 
 

--- a/proxmoxer/core.py
+++ b/proxmoxer/core.py
@@ -47,7 +47,7 @@ SERVICES = {
         "supported_https_auths": ["password", "token"],
         "default_port": 8443,
         "token_separator": ":",
-    }
+    },
 }
 
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -308,6 +308,27 @@ class TestProxmoxAPI:
 
         assert str(exc_info.value) == "PBS service does not support local backend"
 
+    def test_init_pdm_https(self):
+        prox = core.ProxmoxAPI(
+            "host", token_name="name", token_value="value", service="pdm", backend="https"
+        )
+
+        assert isinstance(prox, core.ProxmoxAPI)
+        assert prox._backend.auth.service == "PDM"
+
+    def test_init_pdm_invalid_backend(self):
+        with pytest.raises(NotImplementedError) as exc_info:
+            core.ProxmoxAPI("host", service="pdm", backend="local")
+
+        assert str(exc_info.value) == "PDM service does not support local backend"
+
+    def test_repr_pdm_https(self):
+        prox = core.ProxmoxAPI(
+            "host", token_name="name", token_value="value", service="pdm", backend="https"
+        )
+
+        assert repr(prox) == "ProxmoxAPI (https backend for https://host:8443/api2/json)"
+
     def test_init_local_with_host(self):
         with pytest.raises(NotImplementedError) as exc_info:
             core.ProxmoxAPI("host", service="pve", backend="LocaL")


### PR DESCRIPTION
Registers PDM as a supported service, accessible via the https backend on its default port 8443 with password or token authentication.

Changes:
- proxmoxer/core.py: add PDM entry to the SERVICES registry
- tests/test_core.py: add tests covering PDM initialization, unsupported backend rejection, and repr output